### PR TITLE
chore: removes deplicated proto fields

### DIFF
--- a/api/queueservice/v1/request_response.pb.go
+++ b/api/queueservice/v1/request_response.pb.go
@@ -437,13 +437,12 @@ func (x *GetNextMessageRequest) GetAttemptId() string {
 }
 
 type GetNextMessageResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Message       *v11.Message           `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
-	StreamEntryId string                 `protobuf:"bytes,2,opt,name=stream_entry_id,json=streamEntryId,proto3" json:"stream_entry_id,omitempty"`
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	Message *v11.Message           `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
 	// Echo or assign the worker_id used for this lease
-	WorkerId *string `protobuf:"bytes,3,opt,name=worker_id,json=workerId,proto3,oneof" json:"worker_id,omitempty"`
+	WorkerId *string `protobuf:"bytes,2,opt,name=worker_id,json=workerId,proto3,oneof" json:"worker_id,omitempty"`
 	// Attempt identifier for this lease
-	AttemptId     *string `protobuf:"bytes,4,opt,name=attempt_id,json=attemptId,proto3,oneof" json:"attempt_id,omitempty"`
+	AttemptId     *string `protobuf:"bytes,3,opt,name=attempt_id,json=attemptId,proto3,oneof" json:"attempt_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -485,13 +484,6 @@ func (x *GetNextMessageResponse) GetMessage() *v11.Message {
 	return nil
 }
 
-func (x *GetNextMessageResponse) GetStreamEntryId() string {
-	if x != nil {
-		return x.StreamEntryId
-	}
-	return ""
-}
-
 func (x *GetNextMessageResponse) GetWorkerId() string {
 	if x != nil && x.WorkerId != nil {
 		return *x.WorkerId
@@ -508,15 +500,14 @@ func (x *GetNextMessageResponse) GetAttemptId() string {
 
 // Acknowledge the message on the queue
 type AcknowledgeMessageRequest struct {
-	state         protoimpl.MessageState     `protogen:"open.v1"`
-	QueueName     string                     `protobuf:"bytes,1,opt,name=queue_name,json=queueName,proto3" json:"queue_name,omitempty"`
-	MessageId     string                     `protobuf:"bytes,2,opt,name=message_id,json=messageId,proto3" json:"message_id,omitempty"`
-	State         v11.Message_Metadata_State `protobuf:"varint,3,opt,name=state,proto3,enum=chronoqueue.api.message.v1.Message_Metadata_State" json:"state,omitempty"`
-	StreamEntryId string                     `protobuf:"bytes,4,opt,name=stream_entry_id,json=streamEntryId,proto3" json:"stream_entry_id,omitempty"`
+	state     protoimpl.MessageState     `protogen:"open.v1"`
+	QueueName string                     `protobuf:"bytes,1,opt,name=queue_name,json=queueName,proto3" json:"queue_name,omitempty"`
+	MessageId string                     `protobuf:"bytes,2,opt,name=message_id,json=messageId,proto3" json:"message_id,omitempty"`
+	State     v11.Message_Metadata_State `protobuf:"varint,3,opt,name=state,proto3,enum=chronoqueue.api.message.v1.Message_Metadata_State" json:"state,omitempty"`
 	// Optional stable identifier to consistently represent the same consumer
-	WorkerId *string `protobuf:"bytes,5,opt,name=worker_id,json=workerId,proto3,oneof" json:"worker_id,omitempty"`
+	WorkerId *string `protobuf:"bytes,4,opt,name=worker_id,json=workerId,proto3,oneof" json:"worker_id,omitempty"`
 	// Attempt identifier to validate acknowledgment against current attempt
-	AttemptId     *string `protobuf:"bytes,6,opt,name=attempt_id,json=attemptId,proto3,oneof" json:"attempt_id,omitempty"`
+	AttemptId     *string `protobuf:"bytes,5,opt,name=attempt_id,json=attemptId,proto3,oneof" json:"attempt_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -570,13 +561,6 @@ func (x *AcknowledgeMessageRequest) GetState() v11.Message_Metadata_State {
 		return x.State
 	}
 	return v11.Message_Metadata_State(0)
-}
-
-func (x *AcknowledgeMessageRequest) GetStreamEntryId() string {
-	if x != nil {
-		return x.StreamEntryId
-	}
-	return ""
 }
 
 func (x *AcknowledgeMessageRequest) GetWorkerId() string {
@@ -954,14 +938,13 @@ func (x *GetQueueStateResponse) GetEarliestDeadline() *timestamppb.Timestamp {
 
 // send a heartbeat to the queue
 type SendMessageHeartBeatRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	QueueName     string                 `protobuf:"bytes,1,opt,name=queue_name,json=queueName,proto3" json:"queue_name,omitempty"`
-	MessageId     string                 `protobuf:"bytes,2,opt,name=message_id,json=messageId,proto3" json:"message_id,omitempty"`
-	StreamEntryId string                 `protobuf:"bytes,3,opt,name=stream_entry_id,json=streamEntryId,proto3" json:"stream_entry_id,omitempty"`
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	QueueName string                 `protobuf:"bytes,1,opt,name=queue_name,json=queueName,proto3" json:"queue_name,omitempty"`
+	MessageId string                 `protobuf:"bytes,2,opt,name=message_id,json=messageId,proto3" json:"message_id,omitempty"`
 	// Optional stable identifier to consistently represent the same consumer
-	WorkerId *string `protobuf:"bytes,4,opt,name=worker_id,json=workerId,proto3,oneof" json:"worker_id,omitempty"`
+	WorkerId *string `protobuf:"bytes,3,opt,name=worker_id,json=workerId,proto3,oneof" json:"worker_id,omitempty"`
 	// Attempt identifier to validate heartbeat against current attempt
-	AttemptId     *string `protobuf:"bytes,5,opt,name=attempt_id,json=attemptId,proto3,oneof" json:"attempt_id,omitempty"`
+	AttemptId     *string `protobuf:"bytes,4,opt,name=attempt_id,json=attemptId,proto3,oneof" json:"attempt_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1006,13 +989,6 @@ func (x *SendMessageHeartBeatRequest) GetQueueName() string {
 func (x *SendMessageHeartBeatRequest) GetMessageId() string {
 	if x != nil {
 		return x.MessageId
-	}
-	return ""
-}
-
-func (x *SendMessageHeartBeatRequest) GetStreamEntryId() string {
-	if x != nil {
-		return x.StreamEntryId
 	}
 	return ""
 }
@@ -3381,26 +3357,24 @@ const file_proto_queueservice_v1_request_response_proto_rawDesc = "" +
 	"attempt_id\x18\x05 \x01(\tH\x01R\tattemptId\x88\x01\x01B\f\n" +
 	"\n" +
 	"_worker_idB\r\n" +
-	"\v_attempt_id\"\xe2\x01\n" +
+	"\v_attempt_id\"\xba\x01\n" +
 	"\x16GetNextMessageResponse\x12=\n" +
-	"\amessage\x18\x01 \x01(\v2#.chronoqueue.api.message.v1.MessageR\amessage\x12&\n" +
-	"\x0fstream_entry_id\x18\x02 \x01(\tR\rstreamEntryId\x12 \n" +
-	"\tworker_id\x18\x03 \x01(\tH\x00R\bworkerId\x88\x01\x01\x12\"\n" +
+	"\amessage\x18\x01 \x01(\v2#.chronoqueue.api.message.v1.MessageR\amessage\x12 \n" +
+	"\tworker_id\x18\x02 \x01(\tH\x00R\bworkerId\x88\x01\x01\x12\"\n" +
 	"\n" +
-	"attempt_id\x18\x04 \x01(\tH\x01R\tattemptId\x88\x01\x01B\f\n" +
+	"attempt_id\x18\x03 \x01(\tH\x01R\tattemptId\x88\x01\x01B\f\n" +
 	"\n" +
 	"_worker_idB\r\n" +
-	"\v_attempt_id\"\xae\x02\n" +
+	"\v_attempt_id\"\x86\x02\n" +
 	"\x19AcknowledgeMessageRequest\x12\x1d\n" +
 	"\n" +
 	"queue_name\x18\x01 \x01(\tR\tqueueName\x12\x1d\n" +
 	"\n" +
 	"message_id\x18\x02 \x01(\tR\tmessageId\x12H\n" +
-	"\x05state\x18\x03 \x01(\x0e22.chronoqueue.api.message.v1.Message.Metadata.StateR\x05state\x12&\n" +
-	"\x0fstream_entry_id\x18\x04 \x01(\tR\rstreamEntryId\x12 \n" +
-	"\tworker_id\x18\x05 \x01(\tH\x00R\bworkerId\x88\x01\x01\x12\"\n" +
+	"\x05state\x18\x03 \x01(\x0e22.chronoqueue.api.message.v1.Message.Metadata.StateR\x05state\x12 \n" +
+	"\tworker_id\x18\x04 \x01(\tH\x00R\bworkerId\x88\x01\x01\x12\"\n" +
 	"\n" +
-	"attempt_id\x18\x06 \x01(\tH\x01R\tattemptId\x88\x01\x01B\f\n" +
+	"attempt_id\x18\x05 \x01(\tH\x01R\tattemptId\x88\x01\x01B\f\n" +
 	"\n" +
 	"_worker_idB\r\n" +
 	"\v_attempt_id\"6\n" +
@@ -3434,16 +3408,15 @@ const file_proto_queueservice_v1_request_response_proto_rawDesc = "" +
 	"\x11earliest_deadline\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\x10earliestDeadline\x1a>\n" +
 	"\x10StateCountsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\x05R\x05value:\x028\x01\"\xe6\x01\n" +
+	"\x05value\x18\x02 \x01(\x05R\x05value:\x028\x01\"\xbe\x01\n" +
 	"\x1bSendMessageHeartBeatRequest\x12\x1d\n" +
 	"\n" +
 	"queue_name\x18\x01 \x01(\tR\tqueueName\x12\x1d\n" +
 	"\n" +
-	"message_id\x18\x02 \x01(\tR\tmessageId\x12&\n" +
-	"\x0fstream_entry_id\x18\x03 \x01(\tR\rstreamEntryId\x12 \n" +
-	"\tworker_id\x18\x04 \x01(\tH\x00R\bworkerId\x88\x01\x01\x12\"\n" +
+	"message_id\x18\x02 \x01(\tR\tmessageId\x12 \n" +
+	"\tworker_id\x18\x03 \x01(\tH\x00R\bworkerId\x88\x01\x01\x12\"\n" +
 	"\n" +
-	"attempt_id\x18\x05 \x01(\tH\x01R\tattemptId\x88\x01\x01B\f\n" +
+	"attempt_id\x18\x04 \x01(\tH\x01R\tattemptId\x88\x01\x01B\f\n" +
 	"\n" +
 	"_worker_idB\r\n" +
 	"\v_attempt_id\"\xaa\x01\n" +

--- a/client/client.go
+++ b/client/client.go
@@ -154,13 +154,12 @@ type ClientOptions struct {
 }
 
 type WorkItem struct {
-	ctx           context.Context
-	cancel        context.CancelFunc
-	queue         string
-	messageID     string
-	streamEntryID string // Redis Stream entry ID for XCLAIM-based heartbeats
-	attemptID     string
-	workerID      string
+	ctx       context.Context
+	cancel    context.CancelFunc
+	queue     string
+	messageID string
+	attemptID string
+	workerID  string
 }
 
 type attemptInfo struct {
@@ -316,7 +315,7 @@ func (client *ChronoQueueClient) SetAttemptInfo(messageID, attemptID, workerID s
 func (client *ChronoQueueClient) heartbeatWorker() {
 	for workItem := range client.workChan {
 		// Perform work here, e.g., manage heartbeats
-		client.manageHeartbeats(workItem.ctx, workItem.queue, workItem.messageID, workItem.streamEntryID, workItem.attemptID, workItem.workerID)
+		client.manageHeartbeats(workItem.ctx, workItem.queue, workItem.messageID, workItem.attemptID, workItem.workerID)
 	}
 }
 
@@ -537,7 +536,7 @@ func (client *ChronoQueueClient) PostMessage(ctx context.Context, queue string, 
 	return res, nil
 }
 
-func (client *ChronoQueueClient) manageHeartbeats(ctx context.Context, queueName string, messageId string, streamEntryID string, attemptID string, workerID string) {
+func (client *ChronoQueueClient) manageHeartbeats(ctx context.Context, queueName string, messageId string, attemptID string, workerID string) {
 	if attemptID != "" || workerID != "" {
 		client.recordAttemptInfo(messageId, attemptID, workerID)
 	}
@@ -564,7 +563,7 @@ func (client *ChronoQueueClient) manageHeartbeats(ctx context.Context, queueName
 			// Use background context for RPC, not the heartbeat lifecycle context
 			rpcCtx, rpcCancel := context.WithTimeout(context.Background(), client.opts.DefaultRPCTimeout)
 
-			_, err := client.SendMessageHeartbeat(rpcCtx, queueName, messageId, streamEntryID)
+			_, err := client.SendMessageHeartbeat(rpcCtx, queueName, messageId)
 			rpcCancel() // Always cancel RPC context after use
 
 			if err != nil {
@@ -658,13 +657,12 @@ func (client *ChronoQueueClient) GetNextMessage(ctx context.Context, queue strin
 		client.activeHeartbeats.Store(res.Message.MessageId, heartbeatCancel)
 
 		client.workChan <- WorkItem{
-			ctx:           heartbeatCtx,
-			cancel:        heartbeatCancel,
-			queue:         queue,
-			messageID:     res.Message.MessageId,
-			streamEntryID: res.StreamEntryId, // Capture stream entry ID for Redis Streams
-			attemptID:     attemptID,
-			workerID:      workerID,
+			ctx:       heartbeatCtx,
+			cancel:    heartbeatCancel,
+			queue:     queue,
+			messageID: res.Message.MessageId,
+			attemptID: attemptID,
+			workerID:  workerID,
 		}
 	}
 	return res, nil
@@ -729,8 +727,7 @@ func (client *ChronoQueueClient) RenewMessageLease(ctx context.Context, queue st
 
 // AcknowledgeMessage updates state of a message and empty response
 // Automatically stops heartbeat for the message if one is active.
-// The streamEntryID is the Redis Stream entry ID returned from GetNextMessage.
-func (client *ChronoQueueClient) AcknowledgeMessage(ctx context.Context, queue string, messageId string, state State, streamEntryID string) (*queueservice_pb.AcknowledgeMessageResponse, error) {
+func (client *ChronoQueueClient) AcknowledgeMessage(ctx context.Context, queue string, messageId string, state State) (*queueservice_pb.AcknowledgeMessageResponse, error) {
 	// Stop heartbeat before acknowledging (if active)
 	client.StopHeartbeat(messageId)
 
@@ -740,10 +737,9 @@ func (client *ChronoQueueClient) AcknowledgeMessage(ctx context.Context, queue s
 	}
 
 	req := &queueservice_pb.AcknowledgeMessageRequest{
-		QueueName:     queue,
-		MessageId:     messageId,
-		State:         message_pb.Message_Metadata_State(state),
-		StreamEntryId: streamEntryID,
+		QueueName: queue,
+		MessageId: messageId,
+		State:     message_pb.Message_Metadata_State(state),
 	}
 
 	info := client.getAttemptInfo(messageId)
@@ -769,8 +765,7 @@ func (client *ChronoQueueClient) AcknowledgeMessage(ctx context.Context, queue s
 }
 
 // SendMessageHeartbeat sends a heartbeat for an in-flight message.
-// The streamEntryID is the Redis Stream entry ID returned from GetNextMessage.
-func (client *ChronoQueueClient) SendMessageHeartbeat(ctx context.Context, queueName string, messageId string, streamEntryID string) (*queueservice_pb.SendMessageHeartBeatResponse, error) {
+func (client *ChronoQueueClient) SendMessageHeartbeat(ctx context.Context, queueName string, messageId string) (*queueservice_pb.SendMessageHeartBeatResponse, error) {
 	if client.opts.SendMessageHeartbeatFunc != nil {
 		return client.opts.SendMessageHeartbeatFunc(ctx, queueName, messageId)
 	}
@@ -789,9 +784,8 @@ func (client *ChronoQueueClient) SendMessageHeartbeat(ctx context.Context, queue
 	attemptID := info.attemptID
 
 	req := &queueservice_pb.SendMessageHeartBeatRequest{
-		QueueName:     queueName,
-		MessageId:     messageId,
-		StreamEntryId: streamEntryID,
+		QueueName: queueName,
+		MessageId: messageId,
 	}
 	if workerID != "" {
 		req.WorkerId = &workerID

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -730,12 +730,11 @@ func TestChronoQueueClient_manageHeartbeats(t *testing.T) {
 	}
 
 	type args struct {
-		ctx           context.Context
-		queueName     string
-		messageId     string
-		streamEntryID string
-		attemptID     string
-		workerID      string
+		ctx       context.Context
+		queueName string
+		messageId string
+		attemptID string
+		workerID  string
 	}
 	tests := []struct {
 		name     string
@@ -903,7 +902,7 @@ func TestChronoQueueClient_manageHeartbeats(t *testing.T) {
 			tt.setup(&tt.fields, client)
 
 			// Use a separate goroutine as manageHeartbeats is blocking
-			go client.manageHeartbeats(tt.args.ctx, tt.args.queueName, tt.args.messageId, tt.args.streamEntryID, tt.args.attemptID, tt.args.workerID)
+			go client.manageHeartbeats(tt.args.ctx, tt.args.queueName, tt.args.messageId, tt.args.attemptID, tt.args.workerID)
 
 			// Add a small sleep to allow for asynchronous operations to execute
 			// Note: This might need to be adjusted based on actual behavior
@@ -1285,7 +1284,7 @@ func TestChronoQueueClient_AcknowledgeMessage(t *testing.T) {
 			}
 			defer client.Close()
 
-			got, err := client.AcknowledgeMessage(tt.args.ctx, tt.args.queue, tt.args.messageId, tt.args.state, "")
+			got, err := client.AcknowledgeMessage(tt.args.ctx, tt.args.queue, tt.args.messageId, tt.args.state)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ChronoQueueClient.AcknowledgeMessage() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -1327,7 +1326,7 @@ func TestChronoQueueClient_AcknowledgeMessage_WithAttemptInfo(t *testing.T) {
 	defer client.Close()
 
 	client.SetAttemptInfo("msg-1", "attempt-123", "worker-xyz")
-	_, err = client.AcknowledgeMessage(context.Background(), "q1", "msg-1", 3, "")
+	_, err = client.AcknowledgeMessage(context.Background(), "q1", "msg-1", 3)
 	if err != nil {
 		t.Fatalf("ack failed: %v", err)
 	}
@@ -1388,7 +1387,7 @@ func TestChronoQueueClient_SendMessageHeartbeat(t *testing.T) {
 			}
 			defer client.Close()
 
-			got, err := client.SendMessageHeartbeat(tt.args.ctx, tt.args.queueName, tt.args.messageId, "")
+			got, err := client.SendMessageHeartbeat(tt.args.ctx, tt.args.queueName, tt.args.messageId)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ChronoQueueClient.SendMessageHeartbeat() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/cmd/chronoq/commands/message.go
+++ b/cmd/chronoq/commands/message.go
@@ -214,7 +214,6 @@ func newMessageGetCommand() *cobra.Command {
 					return nil
 				}
 				outputs.PrintInfo(fmt.Sprintf("Message ID: %s", resp.GetMessage().GetMessageId()))
-				outputs.PrintInfo(fmt.Sprintf("Stream Entry ID: %s", resp.GetStreamEntryId()))
 				if workerID := resp.GetWorkerId(); workerID != "" {
 					outputs.PrintInfo(fmt.Sprintf("Worker ID: %s", workerID))
 				}
@@ -239,18 +238,14 @@ func newMessageGetCommand() *cobra.Command {
 // newMessageAckCommand creates the message acknowledge subcommand
 func newMessageAckCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "ack <queue-name> <message-id> <message-state> [stream-entry-id]",
+		Use:   "ack <queue-name> <message-id> <message-state>",
 		Short: "Acknowledge a message",
-		Long:  `Acknowledge that a message has been processed successfully. The stream-entry-id is optional but recommended for Redis Streams architecture.`,
-		Args:  cobra.RangeArgs(3, 4),
+		Long:  `Acknowledge that a message has been processed successfully.`,
+		Args:  cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			queueName := args[0]
 			messageID := args[1]
 			stateStr := args[2]
-			streamEntryID := ""
-			if len(args) == 4 {
-				streamEntryID = args[3]
-			}
 
 			attemptID, err := cmd.Flags().GetString("attempt-id")
 			if err != nil {
@@ -270,7 +265,7 @@ func newMessageAckCommand() *cobra.Command {
 				if attemptID != "" || workerID != "" {
 					client.SetAttemptInfo(messageID, attemptID, workerID)
 				}
-				resp, err := client.AcknowledgeMessage(cmd.Context(), queueName, messageID, state, streamEntryID)
+				resp, err := client.AcknowledgeMessage(cmd.Context(), queueName, messageID, state)
 				if err != nil {
 					return err
 				}
@@ -364,20 +359,16 @@ func newMessageRenewCommand() *cobra.Command {
 // newMessageHeartbeatCommand creates the message heartbeat subcommand
 func newMessageHeartbeatCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "heartbeat <queue-name> <message-id> [stream-entry-id]",
+		Use:   "heartbeat <queue-name> <message-id>",
 		Short: "Send a heartbeat for a message",
-		Long:  `Send a heartbeat to indicate that a message is still being processed. The stream-entry-id is optional but recommended for Redis Streams architecture.`,
-		Args:  cobra.RangeArgs(2, 3),
+		Long:  `Send a heartbeat to indicate that a message is still being processed.`,
+		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			queueName := args[0]
 			messageID := args[1]
-			streamEntryID := ""
-			if len(args) == 3 {
-				streamEntryID = args[2]
-			}
 
 			return WithClient(cmd, func(client *client.ChronoQueueClient) error {
-				resp, err := client.SendMessageHeartbeat(cmd.Context(), queueName, messageID, streamEntryID)
+				resp, err := client.SendMessageHeartbeat(cmd.Context(), queueName, messageID)
 				if err != nil {
 					return err
 				}

--- a/cmd/chronoq/commands/message_test.go
+++ b/cmd/chronoq/commands/message_test.go
@@ -28,10 +28,10 @@ func TestNewMessageCommand(t *testing.T) {
 	expectedCommands := []string{
 		"post <queue-name> [message-data]",
 		"get <queue-name>",
-		"ack <queue-name> <message-id> <message-state> [stream-entry-id]",
+		"ack <queue-name> <message-id> <message-state>",
 		"peek <queue-name>",
 		"renew <queue-name> <message-id> <lease-duration>",
-		"heartbeat <queue-name> <message-id> [stream-entry-id]",
+		"heartbeat <queue-name> <message-id>",
 	}
 
 	for _, expected := range expectedCommands {
@@ -86,7 +86,7 @@ func TestNewMessageAckCommand(t *testing.T) {
 	cmd := newMessageAckCommand()
 
 	assert.NotNil(t, cmd)
-	assert.Equal(t, "ack <queue-name> <message-id> <message-state> [stream-entry-id]", cmd.Use)
+	assert.Equal(t, "ack <queue-name> <message-id> <message-state>", cmd.Use)
 	assert.Equal(t, "Acknowledge a message", cmd.Short)
 	assert.Contains(t, cmd.Long, "Acknowledge that a message has been processed")
 	assert.NotNil(t, cmd.RunE)
@@ -133,7 +133,7 @@ func TestNewMessageHeartbeatCommand(t *testing.T) {
 	cmd := newMessageHeartbeatCommand()
 
 	assert.NotNil(t, cmd)
-	assert.Equal(t, "heartbeat <queue-name> <message-id> [stream-entry-id]", cmd.Use)
+	assert.Equal(t, "heartbeat <queue-name> <message-id>", cmd.Use)
 	assert.Equal(t, "Send a heartbeat for a message", cmd.Short)
 	assert.Contains(t, cmd.Long, "Send a heartbeat to indicate that a message is still being processed")
 	assert.NotNil(t, cmd.RunE)

--- a/examples/ai-agent-orchestrator/pkg/agents/aggregator_agent.go
+++ b/examples/ai-agent-orchestrator/pkg/agents/aggregator_agent.go
@@ -246,7 +246,7 @@ func (agent *AggregatorAgent) collectResults(ctx context.Context, parentID strin
 		// Parse the result from message payload
 		if msg.Metadata == nil || msg.Metadata.Payload == nil || msg.Metadata.Payload.Data == nil {
 			// Invalid message, ACK to remove it
-			if _, err := agent.client.AcknowledgeMessage(ctx, "agent-results", msg.MessageId, client.MESSAGE_COMPLETED, resp.StreamEntryId); err != nil && agent.verbose {
+			if _, err := agent.client.AcknowledgeMessage(ctx, "agent-results", msg.MessageId, client.MESSAGE_COMPLETED); err != nil && agent.verbose {
 				fmt.Printf("   ⚠️  Failed to ACK invalid message: %v\n", err)
 			}
 			continue
@@ -276,14 +276,14 @@ func (agent *AggregatorAgent) collectResults(ctx context.Context, parentID strin
 				}
 
 				// ACK the message to remove it from queue
-				if _, err := agent.client.AcknowledgeMessage(ctx, "agent-results", msg.MessageId, client.MESSAGE_COMPLETED, resp.StreamEntryId); err != nil {
+				if _, err := agent.client.AcknowledgeMessage(ctx, "agent-results", msg.MessageId, client.MESSAGE_COMPLETED); err != nil {
 					if agent.verbose {
 						fmt.Printf("   ⚠️  Failed to ACK message %s: %v\n", msg.MessageId, err)
 					}
 				}
 			} else {
 				// Already collected, just ACK to remove duplicate
-				if _, err := agent.client.AcknowledgeMessage(ctx, "agent-results", msg.MessageId, client.MESSAGE_COMPLETED, resp.StreamEntryId); err != nil {
+				if _, err := agent.client.AcknowledgeMessage(ctx, "agent-results", msg.MessageId, client.MESSAGE_COMPLETED); err != nil {
 					if agent.verbose {
 						fmt.Printf("   ⚠️  Failed to ACK duplicate message %s: %v\n", msg.MessageId, err)
 					}
@@ -291,7 +291,7 @@ func (agent *AggregatorAgent) collectResults(ctx context.Context, parentID strin
 			}
 		} else {
 			// Not our result, also ACK it (another aggregator task will collect its own results)
-			if _, err := agent.client.AcknowledgeMessage(ctx, "agent-results", msg.MessageId, client.MESSAGE_COMPLETED, resp.StreamEntryId); err != nil {
+			if _, err := agent.client.AcknowledgeMessage(ctx, "agent-results", msg.MessageId, client.MESSAGE_COMPLETED); err != nil {
 				if agent.verbose {
 					fmt.Printf("   ⚠️  Failed to ACK unrelated message %s: %v\n", msg.MessageId, err)
 				}

--- a/examples/ai-agent-orchestrator/pkg/agents/base_agent.go
+++ b/examples/ai-agent-orchestrator/pkg/agents/base_agent.go
@@ -153,7 +153,7 @@ func (agent *BaseAgent) processMessage(ctx context.Context, workerID int, resp *
 	subtask, err := agent.parseSubtask(msg)
 	if err != nil {
 		// Acknowledge with error
-		err := agent.acknowledgeMessage(ctx, resp.StreamEntryId, msg.MessageId, client.MESSAGE_ERRORED)
+		err := agent.acknowledgeMessage(ctx, msg.MessageId, client.MESSAGE_ERRORED)
 		if err != nil {
 			fmt.Printf("[%s Worker %d] Error acknowledging message %s: %v\n", agent.agentType, workerID, msg.MessageId, err)
 		}
@@ -165,7 +165,7 @@ func (agent *BaseAgent) processMessage(ctx context.Context, workerID int, resp *
 	result, err := processor(ctx, subtask)
 	if err != nil {
 		// Acknowledge with error
-		err := agent.acknowledgeMessage(ctx, resp.StreamEntryId, msg.MessageId, client.MESSAGE_ERRORED)
+		err := agent.acknowledgeMessage(ctx, msg.MessageId, client.MESSAGE_ERRORED)
 		if err != nil {
 			fmt.Printf("[%s Worker %d] Error acknowledging message %s: %v\n", agent.agentType, workerID, msg.MessageId, err)
 		}
@@ -186,7 +186,7 @@ func (agent *BaseAgent) processMessage(ctx context.Context, workerID int, resp *
 	}
 
 	// Acknowledge successful processing
-	if err := agent.acknowledgeMessage(ctx, resp.StreamEntryId, msg.MessageId, client.MESSAGE_COMPLETED); err != nil {
+	if err := agent.acknowledgeMessage(ctx, msg.MessageId, client.MESSAGE_COMPLETED); err != nil {
 		return fmt.Errorf("failed to acknowledge message: %w", err)
 	}
 
@@ -252,8 +252,8 @@ func (agent *BaseAgent) postResult(ctx context.Context, result *AgentResult) err
 }
 
 // acknowledgeMessage acknowledges message processing
-func (agent *BaseAgent) acknowledgeMessage(ctx context.Context, streamEntryID, messageID string, state client.State) error {
-	_, err := agent.client.AcknowledgeMessage(ctx, agent.queueName, messageID, state, streamEntryID)
+func (agent *BaseAgent) acknowledgeMessage(ctx context.Context, messageID string, state client.State) error {
+	_, err := agent.client.AcknowledgeMessage(ctx, agent.queueName, messageID, state)
 	return err
 }
 

--- a/examples/ai-agent-orchestrator/pkg/coordinator/coordinator.go
+++ b/examples/ai-agent-orchestrator/pkg/coordinator/coordinator.go
@@ -118,7 +118,6 @@ func (coord *Coordinator) worker(ctx context.Context, workerID int) {
 // processMessage handles a single task message
 func (coord *Coordinator) processMessage(ctx context.Context, workerID int, resp *queueservicev1.GetNextMessageResponse) error {
 	msg := resp.Message
-	streamEntryID := resp.StreamEntryId
 	msgID := msg.MessageId
 
 	if coord.verbose {
@@ -129,7 +128,7 @@ func (coord *Coordinator) processMessage(ctx context.Context, workerID int, resp
 	task, err := coord.parseTask(msg)
 	if err != nil {
 		// Acknowledge to remove from queue (invalid format)
-		if _, ackErr := coord.client.AcknowledgeMessage(ctx, coord.queueName, msgID, client.MESSAGE_ERRORED, streamEntryID); ackErr != nil {
+		if _, ackErr := coord.client.AcknowledgeMessage(ctx, coord.queueName, msgID, client.MESSAGE_ERRORED); ackErr != nil {
 			fmt.Printf("[Worker %d] Warning: failed to acknowledge message: %v\n", workerID, ackErr)
 		}
 		return fmt.Errorf("failed to parse task: %w", err)
@@ -139,7 +138,7 @@ func (coord *Coordinator) processMessage(ctx context.Context, workerID int, resp
 	decomposition, err := coord.llm.DecomposeTask(ctx, task)
 	if err != nil {
 		// Acknowledge to remove from queue (decomposition failed)
-		if _, ackErr := coord.client.AcknowledgeMessage(ctx, coord.queueName, msgID, client.MESSAGE_ERRORED, streamEntryID); ackErr != nil {
+		if _, ackErr := coord.client.AcknowledgeMessage(ctx, coord.queueName, msgID, client.MESSAGE_ERRORED); ackErr != nil {
 			fmt.Printf("[Worker %d] Warning: failed to acknowledge message: %v\n", workerID, ackErr)
 		}
 		return fmt.Errorf("failed to decompose task: %w", err)
@@ -151,14 +150,14 @@ func (coord *Coordinator) processMessage(ctx context.Context, workerID int, resp
 
 	// Route subtasks to appropriate agent queues
 	if err := coord.routeSubtasks(ctx, decomposition); err != nil {
-		if _, ackErr := coord.client.AcknowledgeMessage(ctx, coord.queueName, msgID, client.MESSAGE_ERRORED, streamEntryID); ackErr != nil {
+		if _, ackErr := coord.client.AcknowledgeMessage(ctx, coord.queueName, msgID, client.MESSAGE_ERRORED); ackErr != nil {
 			fmt.Printf("[Worker %d] Warning: failed to acknowledge message: %v\n", workerID, ackErr)
 		}
 		return fmt.Errorf("failed to route subtasks: %w", err)
 	}
 
 	// Acknowledge the original task message
-	_, err = coord.client.AcknowledgeMessage(ctx, coord.queueName, msgID, client.MESSAGE_COMPLETED, streamEntryID)
+	_, err = coord.client.AcknowledgeMessage(ctx, coord.queueName, msgID, client.MESSAGE_COMPLETED)
 	if err != nil {
 		return fmt.Errorf("failed to acknowledge message: %w", err)
 	}

--- a/examples/event-processor/commands.go
+++ b/examples/event-processor/commands.go
@@ -251,7 +251,6 @@ func startWorker(ctx context.Context, workerType string, numWorkers int, name st
 
 		msg := resp.Message
 		msgID := msg.MessageId
-		streamEntryID := resp.StreamEntryId
 
 		var event Event
 		if msg.Metadata != nil && msg.Metadata.Payload != nil && msg.Metadata.Payload.Data != nil {
@@ -264,11 +263,11 @@ func startWorker(ctx context.Context, workerType string, numWorkers int, name st
 
 		if err := processEvent(ctx, workerType, event); err != nil {
 			fmt.Printf("  ❌ [%s] Failed: %v\n", msgID, err)
-			c.AcknowledgeMessage(ctx, queueName, msgID, client.MESSAGE_ERRORED, streamEntryID)
+			c.AcknowledgeMessage(ctx, queueName, msgID, client.MESSAGE_ERRORED)
 			failedCount++
 		} else {
 			fmt.Printf("  ✓ [%s] Successfully processed\n", msgID)
-			c.AcknowledgeMessage(ctx, queueName, msgID, client.MESSAGE_COMPLETED, streamEntryID)
+			c.AcknowledgeMessage(ctx, queueName, msgID, client.MESSAGE_COMPLETED)
 			processedCount++
 		}
 	}

--- a/mcp/src/__tests__/chronoqueue-client.test.ts
+++ b/mcp/src/__tests__/chronoqueue-client.test.ts
@@ -230,7 +230,6 @@ describe('ChronoQueueClient', () => {
                             priority: 5,
                         },
                     },
-                    stream_entry_id: 'entry-1',
                 });
             });
 

--- a/mcp/src/__tests__/handlers.test.ts
+++ b/mcp/src/__tests__/handlers.test.ts
@@ -149,7 +149,6 @@ describe('Tool Handlers', () => {
             mockClient.postMessage.mockResolvedValue({
                 success: true,
                 messageId: 'msg-123',
-                streamEntryId: '1234-0',
             });
 
             const result = await handleToolCall('post_message', {
@@ -172,7 +171,6 @@ describe('Tool Handlers', () => {
             mockClient.postMessage.mockResolvedValue({
                 success: true,
                 messageId: 'msg-123',
-                streamEntryId: '1234-0',
             });
 
             const result = await handleToolCall('post_message', {
@@ -199,7 +197,6 @@ describe('Tool Handlers', () => {
             mockClient.postMessage.mockResolvedValue({
                 success: true,
                 messageId: 'msg-123',
-                streamEntryId: '1234-0',
             });
 
             const result = await handleToolCall('post_message', {
@@ -232,10 +229,8 @@ describe('Tool Handlers', () => {
                     priority: 5,
                     attempts: 0,
                     maxAttempts: 3,
-                    streamEntryId: '1234-0',
                     leasedUntil: '1234567890',
                 },
-                streamEntryId: '1234-0',
             });
 
             const result = await handleToolCall('get_next_message', {
@@ -298,7 +293,6 @@ describe('Tool Handlers', () => {
                 queue_name: 'test-queue',
                 message_id: 'msg-123',
                 status: 'completed',
-                stream_entry_id: '1234-0',
             }, mockClient);
 
             expect(mockClient.acknowledgeMessage).toHaveBeenCalledWith(
@@ -319,7 +313,6 @@ describe('Tool Handlers', () => {
             const result = await handleToolCall('renew_message_lease', {
                 queue_name: 'test-queue',
                 message_id: 'msg-123',
-                stream_entry_id: '1234-0',
                 lease_duration: '60s',
             }, mockClient);
 

--- a/mcp/src/__tests__/tool-definitions.test.ts
+++ b/mcp/src/__tests__/tool-definitions.test.ts
@@ -80,7 +80,6 @@ describe('Tool Definitions', () => {
             expect(tool?.inputSchema.required).toContain('queue_name');
             expect(tool?.inputSchema.required).toContain('message_id');
             expect(tool?.inputSchema.required).toContain('status');
-            expect(tool?.inputSchema.required).toContain('stream_entry_id');
         });
 
         it('create_schedule should have required fields', () => {

--- a/mcp/src/chronoqueue-client.ts
+++ b/mcp/src/chronoqueue-client.ts
@@ -360,7 +360,6 @@ export class ChronoQueueClient {
         return {
             success: response.success,
             messageId: messageId,
-            streamEntryId: '', // Response doesn't include this
         };
     }
 
@@ -396,9 +395,7 @@ export class ChronoQueueClient {
                     maxAttempts: msgMetadata.max_attempts || 0,
                     createdAt: '',
                     leasedUntil: msgMetadata.lease_expiry || '',
-                    streamEntryId: response.stream_entry_id,
                 },
-                streamEntryId: response.stream_entry_id,
             };
         } catch (error: any) {
             if (error.code === grpc.status.NOT_FOUND) {
@@ -439,9 +436,7 @@ export class ChronoQueueClient {
                     maxAttempts: metadata.max_attempts || 0,
                     createdAt: '',
                     leasedUntil: metadata.lease_expiry || '',
-                    streamEntryId: '',
                 },
-                streamEntryId: '',
             };
         });
     }
@@ -452,8 +447,7 @@ export class ChronoQueueClient {
     async acknowledgeMessage(
         queueName: string,
         messageId: string,
-        status: 'completed' | 'errored',
-        streamEntryId: string
+        status: 'completed' | 'errored'
     ): Promise<AcknowledgeMessageResponse> {
         const ackMessageAsync = promisify(
             this.queueServiceClient.acknowledgeMessage.bind(this.queueServiceClient)
@@ -471,7 +465,6 @@ export class ChronoQueueClient {
             queue_name: queueName,
             message_id: messageId,
             state: stateMap[status],
-            stream_entry_id: streamEntryId,
         }, metadata, { deadline });
 
         return {
@@ -533,7 +526,6 @@ export class ChronoQueueClient {
     async renewMessageLease(
         queueName: string,
         messageId: string,
-        streamEntryId: string,
         leaseDuration?: number // Duration in seconds
     ): Promise<{ success: boolean; newLeaseExpiry: string }> {
         const renewLeaseAsync = promisify(
@@ -548,7 +540,6 @@ export class ChronoQueueClient {
         const response = await renewLeaseAsync({
             queue_name: queueName,
             message_id: messageId,
-            stream_entry_id: streamEntryId,
             lease_duration: leaseDurationProto,
         }, metadata, { deadline });
 

--- a/mcp/src/tools/handlers.ts
+++ b/mcp/src/tools/handlers.ts
@@ -173,8 +173,7 @@ async function handlePostMessage(args: any, client: ChronoQueueClient): Promise<
 Queue: ${args.queue_name}
 Message ID: ${args.message_id}
 Priority: ${args.priority || 5}
-${args.schema_id ? `Schema: ${args.schema_id}${args.schema_version ? ` v${args.schema_version}` : ''}` : ''}
-Stream Entry ID: ${response.streamEntryId}`;
+${args.schema_id ? `Schema: ${args.schema_id}${args.schema_version ? ` v${args.schema_version}` : ''}` : ''}`;
 }
 
 async function handleGetNextMessage(args: any, client: ChronoQueueClient): Promise<string> {
@@ -191,14 +190,13 @@ Queue: ${args.queue_name}
 Message ID: ${message.messageId}
 Priority: ${message.priority}
 Attempts: ${message.attempts}/${message.maxAttempts}
-Stream Entry ID: ${response.streamEntryId}
 Leased Until: ${message.leasedUntil || 'N/A'}
 
 Payload:
 ${JSON.stringify(message.payload, null, 2)}
 
 ⚠️  Remember to acknowledge this message after processing using:
-   acknowledge_message with stream_entry_id: ${response.streamEntryId}`;
+   acknowledge_message with message_id: ${message.messageId}`;
 }
 
 async function handlePeekMessages(args: any, client: ChronoQueueClient): Promise<string> {
@@ -226,8 +224,7 @@ async function handleAcknowledgeMessage(args: any, client: ChronoQueueClient): P
     await client.acknowledgeMessage(
         args.queue_name,
         args.message_id,
-        args.status,
-        args.stream_entry_id
+        args.status
     );
 
     const statusEmoji = args.status === 'completed' ? '✅' : '❌';
@@ -248,7 +245,6 @@ async function handleRenewMessageLease(args: any, client: ChronoQueueClient): Pr
     const response = await client.renewMessageLease(
         args.queue_name,
         args.message_id,
-        args.stream_entry_id,
         leaseDurationSeconds
     );
 

--- a/mcp/src/tools/index.ts
+++ b/mcp/src/tools/index.ts
@@ -182,12 +182,8 @@ export const acknowledgeMessageTool: Tool = {
                 enum: ['completed', 'errored'],
                 description: 'Processing status',
             },
-            stream_entry_id: {
-                type: 'string',
-                description: 'Stream entry ID from get_next_message',
-            },
         },
-        required: ['queue_name', 'message_id', 'status', 'stream_entry_id'],
+        required: ['queue_name', 'message_id', 'status'],
     },
 };
 
@@ -205,16 +201,12 @@ export const renewMessageLeaseTool: Tool = {
                 type: 'string',
                 description: 'Message identifier',
             },
-            stream_entry_id: {
-                type: 'string',
-                description: 'Stream entry ID',
-            },
             lease_duration: {
                 type: 'string',
                 description: 'New lease duration (e.g., "5m")',
             },
         },
-        required: ['queue_name', 'message_id', 'stream_entry_id'],
+        required: ['queue_name', 'message_id'],
     },
 };
 

--- a/mcp/src/types/chronoqueue.ts
+++ b/mcp/src/types/chronoqueue.ts
@@ -77,18 +77,15 @@ export interface Message {
     maxAttempts: number;
     createdAt: string;
     leasedUntil?: string;
-    streamEntryId: string;
 }
 
 export interface PostMessageResponse {
     success: boolean;
     messageId: string;
-    streamEntryId: string;
 }
 
 export interface GetMessageResponse {
     message: Message;
-    streamEntryId: string;
 }
 
 export interface AcknowledgeMessageResponse {

--- a/pkg/gateway/chronoqueue.swagger.json
+++ b/pkg/gateway/chronoqueue.swagger.json
@@ -1262,9 +1262,6 @@
         "state": {
           "$ref": "#/definitions/v1MessageMetadataState"
         },
-        "streamEntryId": {
-          "type": "string"
-        },
         "workerId": {
           "type": "string",
           "title": "Optional stable identifier to consistently represent the same consumer"
@@ -1330,9 +1327,6 @@
       "type": "object",
       "properties": {
         "messageId": {
-          "type": "string"
-        },
-        "streamEntryId": {
           "type": "string"
         },
         "workerId": {
@@ -1757,9 +1751,6 @@
       "properties": {
         "message": {
           "$ref": "#/definitions/v1Message"
-        },
-        "streamEntryId": {
-          "type": "string"
         },
         "workerId": {
           "type": "string",

--- a/proto/queueservice/v1/request_response.proto
+++ b/proto/queueservice/v1/request_response.proto
@@ -61,332 +61,355 @@ import "proto/schema/v1/schema.proto";
 
 // Create queue
 message CreateQueueRequest {
-    string name = 1;
-    optional chronoqueue.api.queue.v1.QueueMetadata metadata = 2;
+  string                                          name     = 1;
+  optional chronoqueue.api.queue.v1.QueueMetadata metadata = 2;
 }
+
 message CreateQueueResponse {
-    bool success = 1;
+  bool success = 1;
 }
 
 // Delete queue by name
 message DeleteQueueRequest {
-    string name = 1;
+  string name = 1;
 }
+
 message DeleteQueueResponse {
-    bool success = 1;
+  bool success = 1;
 }
 
 // Post a message to the queue
 message PostMessageRequest{
-    string queue_name = 1;
-    chronoqueue.api.message.v1.Message message = 2;
+  string                             queue_name = 1;
+  chronoqueue.api.message.v1.Message message    = 2;
 }
+
 message PostMessageResponse{
-    bool success = 1;
+  bool success = 1;
 }
-
-
 
 // Get the next message on the queue
 message GetNextMessageRequest{
-    string queue_name = 1;
-    google.protobuf.Duration lease_duration = 2;
-    string exclusivity_key = 3;
+  string                   queue_name      = 1;
+  google.protobuf.Duration lease_duration  = 2;
+  string                   exclusivity_key = 3;
     // Optional stable identifier for the worker/consumer. If absent, server may generate one.
-    optional string worker_id = 4;
+  optional string worker_id = 4;
     // Attempt identifier to validate lease against current attempt
-    optional string attempt_id = 5;
+  optional string attempt_id = 5;
 }
+
 message GetNextMessageResponse{
-    chronoqueue.api.message.v1.Message message = 1;
-    string stream_entry_id = 2;
+  chronoqueue.api.message.v1.Message message = 1;
     // Echo or assign the worker_id used for this lease
-    optional string worker_id = 3;
+  optional string worker_id = 2;
     // Attempt identifier for this lease
-    optional string attempt_id = 4;
+  optional string attempt_id = 3;
 }
 
 // Acknowledge the message on the queue
 message AcknowledgeMessageRequest{
-    string queue_name = 1;
-    string message_id = 2;
-    chronoqueue.api.message.v1.Message.Metadata.State state = 3;
-    string stream_entry_id = 4;
+  string                                            queue_name = 1;
+  string                                            message_id = 2;
+  chronoqueue.api.message.v1.Message.Metadata.State state      = 3;
     // Optional stable identifier to consistently represent the same consumer
-    optional string worker_id = 5;
+  optional string worker_id = 4;
     // Attempt identifier to validate acknowledgment against current attempt
-    optional string attempt_id = 6;
+  optional string attempt_id = 5;
 }
+
 message AcknowledgeMessageResponse{
-    bool success = 1;
+  bool success = 1;
 }
 
 // Renew lease period of a message
 message RenewMessageLeaseRequest{
-    string queue_name = 1;
-    string message_id = 2;
-    google.protobuf.Duration lease_duration = 3;
+  string                   queue_name     = 1;
+  string                   message_id     = 2;
+  google.protobuf.Duration lease_duration = 3;
 }
+
 message RenewMessageLeaseResponse{
-    google.protobuf.Duration remaining_time = 1;
-    chronoqueue.api.message.v1.Message.Metadata.State state = 2;
+  google.protobuf.Duration                          remaining_time = 1;
+  chronoqueue.api.message.v1.Message.Metadata.State state          = 2;
 }
 
 // View pending messages on a queueu
 message PeekQueueMessagesRequest{
-    string queue_name = 1;
-    int64 limit = 2;
-    message PriorityRange {
-        int64 min = 1;
-        int64 max = 2;
-    }
-    optional PeekQueueMessagesRequest.PriorityRange priority_range = 3;
+  string queue_name = 1;
+  int64  limit      = 2;
+  message PriorityRange {
+    int64 min = 1;
+    int64 max = 2;
+  }
+  optional PeekQueueMessagesRequest.PriorityRange priority_range = 3;
 }
+
 message PeekQueueMessagesResponse{
-    repeated chronoqueue.api.message.v1.Message messages = 1;
+  repeated chronoqueue.api.message.v1.Message messages = 1;
 }
 
 // vew the state of a given queue
 message GetQueueStateRequest{
-    string queue_name = 1;
+  string queue_name = 1;
 }
+
 message GetQueueStateResponse{
-    map<string, int32> state_counts = 1;
-    google.protobuf.Timestamp earliest_deadline = 2;
+  map<string, int32>        state_counts      = 1;
+  google.protobuf.Timestamp earliest_deadline = 2;
 }
 
 // send a heartbeat to the queue
 message SendMessageHeartBeatRequest {
-    string queue_name = 1;
-    string message_id = 2;
-    string stream_entry_id = 3;
+  string queue_name = 1;
+  string message_id = 2;
     // Optional stable identifier to consistently represent the same consumer
-    optional string worker_id = 4;
+  optional string worker_id = 3;
     // Attempt identifier to validate heartbeat against current attempt
-    optional string attempt_id = 5;
+  optional string attempt_id = 4;
 }
+
 message SendMessageHeartBeatResponse {
-    google.protobuf.Duration remaining_time = 1;
-    chronoqueue.api.message.v1.Message.Metadata.State state = 2;
+  google.protobuf.Duration                          remaining_time = 1;
+  chronoqueue.api.message.v1.Message.Metadata.State state          = 2;
 }
 
 // List queues
 message ListQueuesRequest {
-    string prefix = 1;
+  string prefix = 1;
 }
+
 message ListQueuesResponse {
-    repeated chronoqueue.api.queue.v1.Queue queues = 1;
+  repeated chronoqueue.api.queue.v1.Queue queues = 1;
 }
 
 // Create a schedule
 message CreateScheduleRequest {
-    chronoqueue.api.schedule.v1.Schedule schedule = 1;
+  chronoqueue.api.schedule.v1.Schedule schedule = 1;
 }
+
 message CreateScheduleResponse {
-    bool success = 1;
+  bool success = 1;
 }
 
 // Delete a schedule
 message DeleteScheduleRequest {
-    string schedule_id = 1;
+  string schedule_id = 1;
 }
+
 message DeleteScheduleResponse {
-    bool success = 1;
+  bool success = 1;
 }
 
 // Pause a schedule
 message PauseScheduleRequest {
-    string schedule_id = 1;
+  string schedule_id = 1;
 }
+
 message PauseScheduleResponse {
-    bool success = 1;
+  bool success = 1;
 }
 
 // Resume a schedule
 message ResumeScheduleRequest {
-    string schedule_id = 1;
+  string schedule_id = 1;
 }
+
 message ResumeScheduleResponse {
-    bool success = 1;
+  bool success = 1;
 }
 
 // Get a schedule
 message GetScheduleRequest {
-    string schedule_id = 1;
+  string schedule_id = 1;
 }
+
 message GetScheduleResponse {
-    chronoqueue.api.schedule.v1.Schedule schedule = 1;
+  chronoqueue.api.schedule.v1.Schedule schedule = 1;
 }
 
 // List schedules
 message ListSchedulesRequest {
-    string prefix = 1;
+  string prefix = 1;
 }
+
 message ListSchedulesResponse {
-    repeated chronoqueue.api.schedule.v1.Schedule schedules = 1;
+  repeated chronoqueue.api.schedule.v1.Schedule schedules = 1;
 }
 
 // Get schedule history
 message GetScheduleHistoryRequest {
-    string schedule_id = 1;
-    int64 limit = 2;
+  string schedule_id = 1;
+  int64  limit       = 2;
 }
+
 message GetScheduleHistoryResponse {
-    chronoqueue.api.schedule.v1.ScheduleHistory schedule_history = 1;
+  chronoqueue.api.schedule.v1.ScheduleHistory schedule_history = 1;
 }
 
 // Dead Letter Queue Management Operations
 
 // Get messages from DLQ
 message GetDLQMessagesRequest {
-    string dlq_name = 1;
-    int32 limit = 2;
+  string dlq_name = 1;
+  int32  limit    = 2;
 }
+
 message GetDLQMessagesResponse {
-    repeated chronoqueue.api.message.v1.Message messages = 1;
+  repeated chronoqueue.api.message.v1.Message messages = 1;
 }
 
 // Requeue message from DLQ back to original queue
 message RequeueFromDLQRequest {
-    string dlq_name = 1;
-    string message_id = 2;
-    string target_queue = 3;
+  string dlq_name     = 1;
+  string message_id   = 2;
+  string target_queue = 3;
 }
+
 message RequeueFromDLQResponse {
-    bool success = 1;
+  bool success = 1;
 }
 
 // Delete message from DLQ
 message DeleteFromDLQRequest {
-    string dlq_name = 1;
-    string message_id = 2;
+  string dlq_name   = 1;
+  string message_id = 2;
 }
+
 message DeleteFromDLQResponse {
-    bool success = 1;
+  bool success = 1;
 }
 
 // Purge all messages from DLQ
 message PurgeDLQRequest {
-    string dlq_name = 1;
+  string dlq_name = 1;
 }
+
 message PurgeDLQResponse {
-    bool success = 1;
+  bool success = 1;
 }
 
 // Get DLQ statistics
 message GetDLQStatsRequest {
-    string dlq_name = 1;
+  string dlq_name = 1;
 }
+
 message GetDLQStatsResponse {
-    string name = 1;
-    int64 message_count = 2;
-    int64 created_at = 3;
-    int64 updated_at = 4;
+  string name          = 1;
+  int64  message_count = 2;
+  int64  created_at    = 3;
+  int64  updated_at    = 4;
 }
 
 // Calendar Schedule Operations
 
 // Validate a calendar schedule configuration
 message ValidateCalendarScheduleRequest {
-    chronoqueue.api.schedule.v1.CalendarSchedule calendar_schedule = 1;
+  chronoqueue.api.schedule.v1.CalendarSchedule calendar_schedule = 1;
 }
+
 message ValidateCalendarScheduleResponse {
-    bool valid = 1;
-    string error_message = 2;
-    repeated ValidationIssue validation_issues = 3;
+  bool                     valid             = 1;
+  string                   error_message     = 2;
+  repeated ValidationIssue validation_issues = 3;
 }
 
 // Preview upcoming execution times for a calendar schedule
 message PreviewCalendarScheduleRequest {
-    chronoqueue.api.schedule.v1.CalendarSchedule calendar_schedule = 1;
-    int32 count = 2; // Number of execution times to preview (default: 10, max: 100)
+  chronoqueue.api.schedule.v1.CalendarSchedule calendar_schedule = 1;
+  int32                                        count             = 2; // Number of execution times to preview (default: 10, max: 100)
 }
+
 message PreviewCalendarScheduleResponse {
-    repeated google.protobuf.Timestamp execution_times = 1;
-    string timezone = 2;
-    google.protobuf.Timestamp preview_start = 3;
-    int32 total_count = 4;
+  repeated google.protobuf.Timestamp execution_times = 1;
+  string                             timezone        = 2;
+  google.protobuf.Timestamp          preview_start   = 3;
+  int32                              total_count     = 4;
 }
 
 // Validation issue details
 message ValidationIssue {
-    string severity = 1; // "error", "warning", "info"
-    int32 rule_index = 2; // -1 for global issues
-    string field = 3;
-    string message = 4;
-    string suggestion = 5;
+  string severity   = 1; // "error", "warning", "info"
+  int32  rule_index = 2; // -1 for global issues
+  string field      = 3;
+  string message    = 4;
+  string suggestion = 5;
 }
 
 // Schema Management Operations
 
 // Register a new schema or schema version
 message RegisterSchemaRequest {
-    string schema_id = 1;           // Unique schema identifier
-    string name = 2;                // Human-readable schema name
-    string description = 3;         // Schema description
-    string content = 4;             // JSON Schema content
-    string content_type = 5;        // Schema type (default: "json-schema")
-    map<string, string> metadata = 6; // Additional metadata
+  string              schema_id    = 1; // Unique schema identifier
+  string              name         = 2; // Human-readable schema name
+  string              description  = 3; // Schema description
+  string              content      = 4; // JSON Schema content
+  string              content_type = 5; // Schema type (default: "json-schema")
+  map<string, string> metadata     = 6; // Additional metadata
 }
+
 message RegisterSchemaResponse {
-    string schema_id = 1;           // Schema identifier
-    int32 version = 2;              // Assigned schema version
-    int64 created_at = 3;           // Creation timestamp
+  string schema_id  = 1; // Schema identifier
+  int32  version    = 2; // Assigned schema version
+  int64  created_at = 3; // Creation timestamp
 }
 
 // Get a specific schema version
 message GetSchemaRequest {
-    string schema_id = 1;           // Schema identifier
-    int32 version = 2;              // Schema version (0 = latest)
+  string schema_id = 1; // Schema identifier
+  int32  version   = 2; // Schema version (0 = latest)
 }
+
 message GetSchemaResponse {
-    chronoqueue.api.schema.v1.Schema schema = 1; // Full schema object
+  chronoqueue.api.schema.v1.Schema schema = 1; // Full schema object
 }
 
 // List schemas with optional filtering
 message ListSchemasRequest {
-    string prefix = 1;              // Filter by schema_id prefix
-    int32 limit = 2;                // Maximum number of results (default: 100)
-    bool active_only = 3;           // Only return active schemas
+  string prefix      = 1; // Filter by schema_id prefix
+  int32  limit       = 2; // Maximum number of results (default: 100)
+  bool   active_only = 3; // Only return active schemas
 }
+
 message ListSchemasResponse {
-    repeated SchemaInfo schemas = 1;
-    int32 total_count = 2;
+  repeated SchemaInfo schemas     = 1;
+  int32               total_count = 2;
 }
 
 // Schema information for list responses
 // Note: This is a summary view with aggregated version info, different from schema.v1.Schema
 message SchemaInfo {
-    string schema_id = 1;
-    int32 latest_version = 2;       // Latest version number
-    string name = 3;
-    string description = 4;
-    int64 created_at = 5;
-    int64 updated_at = 6;
-    int32 version_count = 7;        // Total number of versions
-    bool is_active = 8;
+  string schema_id      = 1;
+  int32  latest_version = 2; // Latest version number
+  string name           = 3;
+  string description    = 4;
+  int64  created_at     = 5;
+  int64  updated_at     = 6;
+  int32  version_count  = 7; // Total number of versions
+  bool   is_active      = 8;
 }
 
 // Delete a schema or specific version
 message DeleteSchemaRequest {
-    string schema_id = 1;           // Schema identifier
-    int32 version = 2;              // Schema version (0 = delete all versions)
+  string schema_id = 1; // Schema identifier
+  int32  version   = 2; // Schema version (0 = delete all versions)
 }
+
 message DeleteSchemaResponse {
-    bool success = 1;
-    int32 versions_deleted = 2;     // Number of versions deleted
+  bool  success          = 1;
+  int32 versions_deleted = 2; // Number of versions deleted
 }
 
 // Validate a payload against a schema
 message ValidatePayloadRequest {
-    string schema_id = 1;           // Schema identifier
-    int32 version = 2;              // Schema version (0 = latest)
-    string payload = 3;             // JSON payload to validate
-}
-message ValidatePayloadResponse {
-    bool valid = 1;
-    repeated chronoqueue.api.schema.v1.ValidationError errors = 2; // Validation errors from schema.proto
-    string schema_id = 3;
-    int32 schema_version = 4;
+  string schema_id = 1; // Schema identifier
+  int32  version   = 2; // Schema version (0 = latest)
+  string payload   = 3; // JSON payload to validate
 }
 
+message ValidatePayloadResponse {
+  bool                                               valid          = 1;
+  repeated chronoqueue.api.schema.v1.ValidationError errors         = 2; // Validation errors from schema.proto
+  string                                             schema_id      = 3;
+  int32                                              schema_version = 4;
+}

--- a/tests/e2e/workflows_test.go
+++ b/tests/e2e/workflows_test.go
@@ -505,12 +505,13 @@ func TestE2E_MultiTenantIsolation(t *testing.T) {
 			tenantAConsumed++
 
 			// Acknowledge with attempt_id
-			_, _ = client.AcknowledgeMessage(ctx, &queueservice_pb.AcknowledgeMessageRequest{
+			_, err = client.AcknowledgeMessage(ctx, &queueservice_pb.AcknowledgeMessageRequest{
 				QueueName: queueName,
 				MessageId: getResp.Message.MessageId,
 				State:     message_pb.Message_Metadata_COMPLETED,
 				AttemptId: getResp.AttemptId,
 			})
+			require.NoError(t, err, "Failed to acknowledge message from Tenant A queue")
 		}
 	}
 	t.Logf("✓ Consumed %d messages from Tenant A", tenantAConsumed)

--- a/tests/e2e/workflows_test.go
+++ b/tests/e2e/workflows_test.go
@@ -127,13 +127,12 @@ func TestE2E_CompleteMessageWorkflow(t *testing.T) {
 
 		t.Logf("  Message %d: %s (priority: %d)", i, getResp.Message.MessageId, getResp.Message.Metadata.Priority)
 
-		// Acknowledge message with attempt_id and stream_entry_id from GetNextMessage response
+		// Acknowledge message with attempt_id from GetNextMessage response
 		_, err = client.AcknowledgeMessage(ctx, &queueservice_pb.AcknowledgeMessageRequest{
-			QueueName:     queueName,
-			MessageId:     getResp.Message.MessageId,
-			State:         message_pb.Message_Metadata_COMPLETED,
-			StreamEntryId: getResp.StreamEntryId,
-			AttemptId:     getResp.AttemptId,
+			QueueName: queueName,
+			MessageId: getResp.Message.MessageId,
+			State:     message_pb.Message_Metadata_COMPLETED,
+			AttemptId: getResp.AttemptId,
 		})
 		require.NoError(t, err, "Failed to acknowledge message")
 		successfulCount++
@@ -204,13 +203,12 @@ func TestE2E_CompleteMessageWorkflow(t *testing.T) {
 				if err == nil && getResp.Message != nil {
 					t.Logf("✓ Retrieved requeued message: %s", getResp.Message.MessageId)
 
-					// Acknowledge it with attempt_id and stream_entry_id
+					// Acknowledge it with attempt_id
 					_, err = client.AcknowledgeMessage(ctx, &queueservice_pb.AcknowledgeMessageRequest{
-						QueueName:     queueName,
-						MessageId:     getResp.Message.MessageId,
-						State:         message_pb.Message_Metadata_COMPLETED,
-						StreamEntryId: getResp.StreamEntryId,
-						AttemptId:     getResp.AttemptId,
+						QueueName: queueName,
+						MessageId: getResp.Message.MessageId,
+						State:     message_pb.Message_Metadata_COMPLETED,
+						AttemptId: getResp.AttemptId,
 					})
 					require.NoError(t, err)
 					t.Log("✓ Requeued message processed successfully")
@@ -506,13 +504,12 @@ func TestE2E_MultiTenantIsolation(t *testing.T) {
 
 			tenantAConsumed++
 
-			// Acknowledge with attempt_id and stream_entry_id
+			// Acknowledge with attempt_id
 			_, _ = client.AcknowledgeMessage(ctx, &queueservice_pb.AcknowledgeMessageRequest{
-				QueueName:     queueName,
-				MessageId:     getResp.Message.MessageId,
-				State:         message_pb.Message_Metadata_COMPLETED,
-				StreamEntryId: getResp.StreamEntryId,
-				AttemptId:     getResp.AttemptId,
+				QueueName: queueName,
+				MessageId: getResp.Message.MessageId,
+				State:     message_pb.Message_Metadata_COMPLETED,
+				AttemptId: getResp.AttemptId,
 			})
 		}
 	}

--- a/tests/integration/message_lifecycle_test.go
+++ b/tests/integration/message_lifecycle_test.go
@@ -536,16 +536,14 @@ func TestMessageLifecycle_AcknowledgeMessage(t *testing.T) {
 	require.NotNil(t, getResp.Message)
 	workerID := getResp.GetWorkerId()
 	attemptID := getResp.GetAttemptId()
-	streamEntryID := getResp.GetStreamEntryId()
 
 	// Act - Acknowledge message
 	ackResp, err := client.AcknowledgeMessage(ctx, &queueservice_pb.AcknowledgeMessageRequest{
-		QueueName:     queueName,
-		MessageId:     getResp.Message.MessageId,
-		State:         message_pb.Message_Metadata_COMPLETED,
-		AttemptId:     &attemptID,
-		WorkerId:      &workerID,
-		StreamEntryId: streamEntryID,
+		QueueName: queueName,
+		MessageId: getResp.Message.MessageId,
+		State:     message_pb.Message_Metadata_COMPLETED,
+		AttemptId: &attemptID,
+		WorkerId:  &workerID,
 	})
 
 	// Assert
@@ -700,7 +698,6 @@ func TestMessageLifecycle_SendHeartbeat(t *testing.T) {
 	require.NotNil(t, getResp.Message)
 	workerID := getResp.GetWorkerId()
 	attemptID := getResp.GetAttemptId()
-	streamEntryID := getResp.GetStreamEntryId()
 
 	// Act - Send heartbeat multiple times to verify lease extension
 	// Use shorter intervals for faster test execution
@@ -708,11 +705,10 @@ func TestMessageLifecycle_SendHeartbeat(t *testing.T) {
 		time.Sleep(1 * time.Second) // Wait 1 second between heartbeats (reduced from 5s)
 
 		heartbeatResp, err := client.SendMessageHeartBeat(ctx, &queueservice_pb.SendMessageHeartBeatRequest{
-			QueueName:     queueName,
-			MessageId:     getResp.Message.MessageId,
-			StreamEntryId: streamEntryID,
-			AttemptId:     &attemptID,
-			WorkerId:      &workerID,
+			QueueName: queueName,
+			MessageId: getResp.Message.MessageId,
+			AttemptId: &attemptID,
+			WorkerId:  &workerID,
 		})
 
 		// Assert

--- a/tests/integration/retention_policy_test.go
+++ b/tests/integration/retention_policy_test.go
@@ -84,15 +84,13 @@ func TestRetentionPolicy_DeleteImmediately(t *testing.T) {
 
 	workerID := getResp.GetWorkerId()
 	attemptID := getResp.GetAttemptId()
-	streamEntryID := getResp.GetStreamEntryId()
 
 	ackResp, err := client.AcknowledgeMessage(ctx, &queueservice_pb.AcknowledgeMessageRequest{
-		QueueName:     queueName,
-		MessageId:     msgID,
-		State:         message_pb.Message_Metadata_COMPLETED,
-		AttemptId:     &attemptID,
-		WorkerId:      &workerID,
-		StreamEntryId: streamEntryID,
+		QueueName: queueName,
+		MessageId: msgID,
+		State:     message_pb.Message_Metadata_COMPLETED,
+		AttemptId: &attemptID,
+		WorkerId:  &workerID,
 	})
 	require.NoError(t, err)
 	assert.True(t, ackResp.Success, "Acknowledgment should succeed")
@@ -174,15 +172,13 @@ func TestRetentionPolicy_RetainDuration(t *testing.T) {
 
 	workerID := getResp.GetWorkerId()
 	attemptID := getResp.GetAttemptId()
-	streamEntryID := getResp.GetStreamEntryId()
 
 	ackResp, err := client.AcknowledgeMessage(ctx, &queueservice_pb.AcknowledgeMessageRequest{
-		QueueName:     queueName,
-		MessageId:     msgID,
-		State:         message_pb.Message_Metadata_COMPLETED,
-		AttemptId:     &attemptID,
-		WorkerId:      &workerID,
-		StreamEntryId: streamEntryID,
+		QueueName: queueName,
+		MessageId: msgID,
+		State:     message_pb.Message_Metadata_COMPLETED,
+		AttemptId: &attemptID,
+		WorkerId:  &workerID,
 	})
 	require.NoError(t, err)
 	assert.True(t, ackResp.Success, "Acknowledgment should succeed")
@@ -271,15 +267,13 @@ func TestRetentionPolicy_RetainForever(t *testing.T) {
 
 	workerID := getResp.GetWorkerId()
 	attemptID := getResp.GetAttemptId()
-	streamEntryID := getResp.GetStreamEntryId()
 
 	ackResp, err := client.AcknowledgeMessage(ctx, &queueservice_pb.AcknowledgeMessageRequest{
-		QueueName:     queueName,
-		MessageId:     msgID,
-		State:         message_pb.Message_Metadata_COMPLETED,
-		AttemptId:     &attemptID,
-		WorkerId:      &workerID,
-		StreamEntryId: streamEntryID,
+		QueueName: queueName,
+		MessageId: msgID,
+		State:     message_pb.Message_Metadata_COMPLETED,
+		AttemptId: &attemptID,
+		WorkerId:  &workerID,
 	})
 	require.NoError(t, err)
 	assert.True(t, ackResp.Success, "Acknowledgment should succeed")
@@ -361,16 +355,14 @@ func TestRetentionPolicy_NackWithRetention(t *testing.T) {
 
 	workerID := getResp.GetWorkerId()
 	attemptID := getResp.GetAttemptId()
-	streamEntryID := getResp.GetStreamEntryId()
 
 	// NACK the message (this exhausts retries since MaxAttempts=1)
 	nackResp, err := client.AcknowledgeMessage(ctx, &queueservice_pb.AcknowledgeMessageRequest{
-		QueueName:     queueName,
-		MessageId:     msgID,
-		State:         message_pb.Message_Metadata_ERRORED,
-		AttemptId:     &attemptID,
-		WorkerId:      &workerID,
-		StreamEntryId: streamEntryID,
+		QueueName: queueName,
+		MessageId: msgID,
+		State:     message_pb.Message_Metadata_ERRORED,
+		AttemptId: &attemptID,
+		WorkerId:  &workerID,
 	})
 	require.NoError(t, err)
 	assert.True(t, nackResp.Success, "NACK should succeed")
@@ -455,15 +447,13 @@ func TestRetentionPolicy_MultipleMessages(t *testing.T) {
 
 		workerID := getResp.GetWorkerId()
 		attemptID := getResp.GetAttemptId()
-		streamEntryID := getResp.GetStreamEntryId()
 
 		_, err = client.AcknowledgeMessage(ctx, &queueservice_pb.AcknowledgeMessageRequest{
-			QueueName:     queueName,
-			MessageId:     getResp.Message.MessageId,
-			State:         message_pb.Message_Metadata_COMPLETED,
-			AttemptId:     &attemptID,
-			WorkerId:      &workerID,
-			StreamEntryId: streamEntryID,
+			QueueName: queueName,
+			MessageId: getResp.Message.MessageId,
+			State:     message_pb.Message_Metadata_COMPLETED,
+			AttemptId: &attemptID,
+			WorkerId:  &workerID,
 		})
 		require.NoError(t, err)
 	}
@@ -551,15 +541,13 @@ func TestRetentionPolicy_ExplicitDeleteImmediately(t *testing.T) {
 
 	workerID := getResp.GetWorkerId()
 	attemptID := getResp.GetAttemptId()
-	streamEntryID := getResp.GetStreamEntryId()
 
 	ackResp, err := client.AcknowledgeMessage(ctx, &queueservice_pb.AcknowledgeMessageRequest{
-		QueueName:     queueName,
-		MessageId:     msgID,
-		State:         message_pb.Message_Metadata_COMPLETED,
-		AttemptId:     &attemptID,
-		WorkerId:      &workerID,
-		StreamEntryId: streamEntryID,
+		QueueName: queueName,
+		MessageId: msgID,
+		State:     message_pb.Message_Metadata_COMPLETED,
+		AttemptId: &attemptID,
+		WorkerId:  &workerID,
 	})
 	require.NoError(t, err)
 	assert.True(t, ackResp.Success, "Acknowledgment should succeed")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Changes**
  * Removed the optional stream-entry identifier from message acknowledge and heartbeat payloads, reducing request/response size and simplifying APIs.
* **CLI**
  * Tightened message commands to require fewer arguments; ack and heartbeat no longer accept the optional stream-entry-id.
* **Tests & Examples**
  * Updated test fixtures and examples to match the simplified API and CLI usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->