### PR TITLE
fix: upgrade go toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: "1.26.5"
+  GO_VERSION: "1.26.6"
   GOLANGCI_LINT_VERSION: v2.5.0
   DOCKER_REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
@@ -253,11 +253,19 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
+      packages: read
       security-events: write
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.DOCKER_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
@@ -266,8 +274,8 @@ jobs:
           format: "sarif"
           output: "trivy-results.sarif"
       - name: Upload Trivy results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
-        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        if: ${{ always() && hashFiles('trivy-results.sarif') != '' }}
         with:
           sarif_file: "trivy-results.sarif"
         continue-on-error: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: "1.26.5"
+  GO_VERSION: "1.26.6"
   PROTOC_VERSION: "32.0"
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
   id-token: write
 
 env:
-  GO_VERSION: "1.26.5"
+  GO_VERSION: "1.26.6"
   DOCKER_REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  GO_VERSION: "1.26.5"
+  GO_VERSION: "1.26.6"
 
 permissions:
   contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ The **dev container** is the recommended approach for developing ChronoQueue. It
 - ✅ **Consistency**: Same environment for all developers and CI
 - ✅ **Isolation**: No conflicts with your local system
 - ✅ **Quick Setup**: Ready to code in minutes
-- ✅ **Includes**: Go 1.26.5, PostgreSQL, SQLite, Docker, kubectl, all dev tools
+- ✅ **Includes**: Go 1.26.6, PostgreSQL, SQLite, Docker, kubectl, all dev tools
 
 **Setup Steps:**
 
@@ -74,7 +74,7 @@ The **dev container** is the recommended approach for developing ChronoQueue. It
 
    ```bash
    # Check Go version
-   go version  # Should show Go 1.26.5
+   go version  # Should show Go 1.26.6
 
    # Check tools are installed
    make check-linter
@@ -95,7 +95,7 @@ If you cannot use dev containers, you can set up manually:
 
 **Prerequisites:**
 
-- Go 1.26.5 or later
+- Go 1.26.6 or later
 - Docker and Docker Compose
 - PostgreSQL 14+ or SQLite 3.35+ (for storage)
 - Make

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -2,7 +2,7 @@
 # and adapted for ChronoQueue development
 
 # [Choice] Go version: 1, 1.21, etc
-ARG GOVERSION=1.26.5
+ARG GOVERSION=1.26.6
 ARG LINUX_VARIANT=bookworm
 FROM golang:${GOVERSION}-${LINUX_VARIANT}
 

--- a/examples/ai-agent-orchestrator/Dockerfile
+++ b/examples/ai-agent-orchestrator/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26.5-alpine AS builder
+FROM golang:1.26.6-alpine AS builder
 
 WORKDIR /build
 

--- a/examples/ai-agent-orchestrator/go.mod
+++ b/examples/ai-agent-orchestrator/go.mod
@@ -1,6 +1,6 @@
 module github.com/adrien19/chronoqueue/examples/ai-agent-orchestrator
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/adrien19/chronoqueue v0.0.0

--- a/examples/event-processor/go.mod
+++ b/examples/event-processor/go.mod
@@ -1,6 +1,6 @@
 module github.com/adrien19/chronoqueue/examples/event-processor
 
-go 1.26.5
+go 1.26.6
 
 replace github.com/adrien19/chronoqueue => ../..
 

--- a/examples/interview-platform/backend/go.mod
+++ b/examples/interview-platform/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/adrien19/chronoqueue/examples/interview-platform/backend
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/adrien19/chronoqueue v0.0.0-00010101000000-000000000000

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@
 
 module github.com/adrien19/chronoqueue
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2
@@ -85,12 +85,12 @@ require (
 	github.com/lufia/plan9stats v0.0.0-20260330125221-c963978e514e // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
-	github.com/moby/go-archive v0.2.0 // indirect
+	github.com/moby/go-archive v0.3.0 // indirect
 	github.com/moby/moby/api v1.55.0 // indirect
 	github.com/moby/moby/client v0.5.0 // indirect
 	github.com/moby/patternmatcher v0.6.1 // indirect
 	github.com/moby/sys/sequential v0.7.0 // indirect
-	github.com/moby/sys/user v0.4.0 // indirect
+	github.com/moby/sys/user v0.4.1 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect
 	github.com/moby/term v0.5.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.sum
+++ b/go.sum
@@ -135,8 +135,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
-github.com/moby/go-archive v0.2.0 h1:zg5QDUM2mi0JIM9fdQZWC7U8+2ZfixfTYoHL7rWUcP8=
-github.com/moby/go-archive v0.2.0/go.mod h1:mNeivT14o8xU+5q1YnNrkQVpK+dnNe/K6fHqnTg4qPU=
+github.com/moby/go-archive v0.3.0 h1:nos4BtzzUIqB406BgQnWGMI4qib9BZ8XUHU+ucv/n1c=
+github.com/moby/go-archive v0.3.0/go.mod h1:Npdv43fFqlhZW7Xo8fbm3ZMYFvAGNviUPqX21VERbcE=
 github.com/moby/moby/api v1.55.0 h1:2/sexvQyqIWS8pRSCFddBfpW2qE7vR7FCL+vN8pxwMc=
 github.com/moby/moby/api v1.55.0/go.mod h1:+RQ6wluLwtYaTd1WnPLykIDPekkuyD/ROWQClE83pzs=
 github.com/moby/moby/client v0.5.0 h1:5XhyPk2fuOWf6RlSFa3MkIIgDZkF25xToXW8Q/BH7cc=
@@ -145,8 +145,8 @@ github.com/moby/patternmatcher v0.6.1 h1:qlhtafmr6kgMIJjKJMDmMWq7WLkKIo23hsrpR3x
 github.com/moby/patternmatcher v0.6.1/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
 github.com/moby/sys/sequential v0.7.0 h1:ASQNGNROJSuOO6LL6bPHbKvuZu6NU8P4ldPWk31zj/8=
 github.com/moby/sys/sequential v0.7.0/go.mod h1:NfSTAp6V3fw4tmkD62PEcOKeZKquXT8VKCkf7aVR79o=
-github.com/moby/sys/user v0.4.0 h1:jhcMKit7SA80hivmFJcbB1vqmw//wU61Zdui2eQXuMs=
-github.com/moby/sys/user v0.4.0/go.mod h1:bG+tYYYJgaMtRKgEmuueC0hJEAZWwtIbZTB+85uoHjs=
+github.com/moby/sys/user v0.4.1 h1:RgjRlaDKi/Xmyrz4t8lyzXT6v2ooFeO/7xtchmhVWE0=
+github.com/moby/sys/user v0.4.1/go.mod h1:E9QsW5WRe1kUAf7kW8hXKwu1uhsZEAdPLYHYSDudF4Y=
 github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g=
 github.com/moby/sys/userns v0.1.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -2,7 +2,7 @@
 # Pure Go build - no CGO, fully static binary, cross-platform compatible
 # For SQLite support, use Dockerfile.sqlite instead
 
-FROM golang:1.26.5-alpine3.24 AS builder
+FROM golang:1.26.6-alpine3.24 AS builder
 
 # Set working directory
 WORKDIR /build

--- a/images/Dockerfile.sqlite
+++ b/images/Dockerfile.sqlite
@@ -2,7 +2,7 @@
 # Requires CGO for SQLite support
 # Used for integration testing and development with full feature set
 
-FROM golang:1.26.5-alpine3.24 as builder
+FROM golang:1.26.6-alpine3.24 as builder
 
 # Install C compiler and musl-dev (required for CGO/SQLite)
 RUN apk add --no-cache gcc musl-dev

--- a/tests/README.md
+++ b/tests/README.md
@@ -47,7 +47,7 @@ tests/
 ### Prerequisites
 
 1. **Docker** must be running (for Testcontainers)
-2. **Go 1.26.5+** installed
+2. **Go 1.26.6+** installed
 3. **ChronoQueue dependencies** installed: `go mod download`
 
 ### Run All Tests


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the project, examples, development containers, Docker images, and automation workflows to use Go 1.26.6.
  - Improved security scan workflow reliability and updated SARIF result handling.

- **Documentation**
  - Updated contributor and testing guidance to reflect the Go 1.26.6 requirement.

- **Bug Fixes**
  - Updated supporting indirect packages used by the project for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->