### PR TITLE
refact: correct active schema fallback and validation

### DIFF
--- a/pkg/repository/backend.go
+++ b/pkg/repository/backend.go
@@ -35,7 +35,7 @@ type BackendStorage interface {
 	CancelMessage(ctx context.Context, queueName string, messageId string, reason string) error
 	NackMessage(ctx context.Context, queueName string, messageId string, attemptId string, workerId string) error
 	HeartbeatMessage(ctx context.Context, queueName string, messageId string, attemptId string, workerId string) (messagepb.Message_Metadata_State, int64, error)
-	ExtendMessageLease(ctx context.Context, queueName string, messageId string, attemptId string, workerId string, extensionMs int64) error
+	ExtendMessageLease(ctx context.Context, queueName string, messageId string, attemptId string, workerId string, extensionMs int64) (int64, error)
 	PeekMessagesWithPriorityRange(ctx context.Context, queueName string, limit int32, priorityRange *repositorysql.PriorityRange) ([]*messagepb.Message, error)
 
 	// Schedule Operations

--- a/pkg/repository/implementation.go
+++ b/pkg/repository/implementation.go
@@ -270,6 +270,11 @@ func (impl *implementation) CreateQueue(ctx context.Context, request *queueservi
 		}
 		return nil, domainerror.New(domainerror.InvalidArgument, err.Error(), err)
 	}
+	if metadata.GetDeadLetterQueueName() != "" && !metadata.GetAutoCreateDlq() {
+		if _, err := impl.backend.GetQueue(ctx, metadata.GetDeadLetterQueueName()); err != nil {
+			return nil, domainerror.PrefixMessage(err, "get configured dead letter queue")
+		}
+	}
 	queue := &queuepb.Queue{
 		Name:     request.Name,
 		Metadata: metadata,
@@ -963,18 +968,13 @@ func (impl *implementation) RenewMessageLease(ctx context.Context, request *queu
 		}
 	}
 
-	if err := impl.backend.ExtendMessageLease(ctx, request.QueueName, request.MessageId, request.GetAttemptId(), request.GetWorkerId(), extensionMs); err != nil {
+	remainingTimeMs, err := impl.backend.ExtendMessageLease(ctx, request.QueueName, request.MessageId, request.GetAttemptId(), request.GetWorkerId(), extensionMs)
+	if err != nil {
 		return nil, err
 	}
 
-	// Return remaining time if lease duration was provided
-	var remainingTime *durationpb.Duration
-	if request.LeaseDuration != nil {
-		remainingTime = request.LeaseDuration
-	}
-
 	return &queueservicepb.RenewMessageLeaseResponse{
-		RemainingTime: remainingTime,
+		RemainingTime: durationpb.New(time.Duration(remainingTimeMs) * time.Millisecond),
 		State:         messagepb.Message_Metadata_RUNNING,
 	}, nil
 }

--- a/pkg/repository/implementation_test.go
+++ b/pkg/repository/implementation_test.go
@@ -86,6 +86,7 @@ type stubBackend struct {
 	enqueueTxErr    error   // transaction-level error for bulk operations
 	cancelled       []cancelledCall
 	cancelErr       error
+	extendRemaining int64
 	pingErr         error
 }
 
@@ -240,8 +241,11 @@ func (b *stubBackend) HeartbeatMessage(ctx context.Context, queueName string, me
 	return messagepb.Message_Metadata_RUNNING, 30000, nil
 }
 
-func (b *stubBackend) ExtendMessageLease(ctx context.Context, queueName string, messageId string, attemptId string, workerId string, extensionMs int64) error {
-	return nil
+func (b *stubBackend) ExtendMessageLease(ctx context.Context, queueName string, messageId string, attemptId string, workerId string, extensionMs int64) (int64, error) {
+	if b.extendRemaining != 0 {
+		return b.extendRemaining, nil
+	}
+	return extensionMs, nil
 }
 
 func (b *stubBackend) PeekMessagesWithPriorityRange(ctx context.Context, queueName string, limit int32, priorityRange *repositorysql.PriorityRange) ([]*messagepb.Message, error) {
@@ -567,6 +571,36 @@ func TestCreateQueue_PreservesOptionalUserDLQName(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, backend.createdQueues, 1)
 	require.Equal(t, "failed-orders", backend.createdQueues[0].GetMetadata().GetDeadLetterQueueName())
+}
+
+func TestCreateQueue_RequiresConfiguredDLQToExist(t *testing.T) {
+	backend := &stubBackend{getQueueErr: domainerror.New(domainerror.NotFound, "queue not found", nil)}
+	impl := &implementation{backend: backend}
+
+	_, err := impl.CreateQueue(context.Background(), &queueservicepb.CreateQueueRequest{
+		Name:     "orders",
+		Metadata: &queuepb.QueueMetadata{DeadLetterQueueName: "missing-dlq"},
+	})
+	require.ErrorContains(t, err, "get configured dead letter queue")
+	require.Empty(t, backend.createdQueues)
+}
+
+func TestRenewMessageLease_ReturnsBackendRemainingTime(t *testing.T) {
+	backend := &stubBackend{extendRemaining: 1_250}
+	impl := &implementation{backend: backend}
+	attemptID := "attempt"
+	workerID := "worker"
+
+	response, err := impl.RenewMessageLease(context.Background(), &queueservicepb.RenewMessageLeaseRequest{
+		QueueName:     "orders",
+		MessageId:     "message",
+		LeaseDuration: durationpb.New(45 * time.Second),
+		AttemptId:     &attemptID,
+		WorkerId:      &workerID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1250*time.Millisecond, response.GetRemainingTime().AsDuration())
+	require.Equal(t, messagepb.Message_Metadata_RUNNING, response.GetState())
 }
 
 func TestGetQueueMessage_ForwardsExclusivityKey(t *testing.T) {

--- a/pkg/repository/postgres/messages.go
+++ b/pkg/repository/postgres/messages.go
@@ -819,11 +819,12 @@ func (s *Storage) ExtendMessageLease(ctx context.Context, queueName string, mess
 	var remainingTimeMs int64
 	err := s.WithTransaction(ctx, nil, func(tx *sql.Tx) error {
 		var messageBytes []byte
+		var currentLeaseExpiry int64
 		var leaseExtensionUsed int64
 		var currentRenewalCount int32
 		nowMs := s.nowMs()
 		query := s.ph(`
-			SELECT metadata_pb, lease_extension_used, lease_renewal_count
+			SELECT metadata_pb, lease_expiry, lease_extension_used, lease_renewal_count
 			FROM cq_messages
 			WHERE queue_name = ? AND message_id = ? AND state = ?
 			  AND current_attempt_id = ? AND current_worker_id = ?
@@ -831,7 +832,7 @@ func (s *Storage) ExtendMessageLease(ctx context.Context, queueName string, mess
 			  AND (heartbeat_expiry IS NULL OR heartbeat_expiry <= 0 OR heartbeat_expiry > ?)
 			  AND deleted_at IS NULL
 			FOR UPDATE`)
-		err := tx.QueryRowContext(ctx, query, queueName, messageId, messagepb.Message_Metadata_RUNNING, attemptId, workerId, nowMs, nowMs).Scan(&messageBytes, &leaseExtensionUsed, &currentRenewalCount)
+		err := tx.QueryRowContext(ctx, query, queueName, messageId, messagepb.Message_Metadata_RUNNING, attemptId, workerId, nowMs, nowMs).Scan(&messageBytes, &currentLeaseExpiry, &leaseExtensionUsed, &currentRenewalCount)
 		if err == sql.ErrNoRows {
 			return s.classifyOwnedMessageFailure(ctx, tx, queueName, messageId, attemptId, workerId, nowMs)
 		}
@@ -854,7 +855,7 @@ func (s *Storage) ExtendMessageLease(ctx context.Context, queueName string, mess
 			}
 		}
 
-		newLeaseRuntime, err := s.LeaseRuntime.ExtendLease(leasePolicy, leaseExtensionUsed, extensionMs)
+		newLeaseRuntime, err := s.LeaseRuntime.ExtendLease(leasePolicy, currentLeaseExpiry, leaseExtensionUsed, extensionMs)
 		if err != nil {
 			return domainerror.New(domainerror.FailedPrecondition, "maximum lease extension reached", err)
 		}

--- a/pkg/repository/postgres/messages.go
+++ b/pkg/repository/postgres/messages.go
@@ -815,8 +815,9 @@ func (s *Storage) CancelMessage(ctx context.Context, queueName string, messageId
 }
 
 // ExtendMessageLease extends the lease on a message.
-func (s *Storage) ExtendMessageLease(ctx context.Context, queueName string, messageId string, attemptId string, workerId string, extensionMs int64) error {
-	return s.WithTransaction(ctx, nil, func(tx *sql.Tx) error {
+func (s *Storage) ExtendMessageLease(ctx context.Context, queueName string, messageId string, attemptId string, workerId string, extensionMs int64) (int64, error) {
+	var remainingTimeMs int64
+	err := s.WithTransaction(ctx, nil, func(tx *sql.Tx) error {
 		var messageBytes []byte
 		var leaseExtensionUsed int64
 		var currentRenewalCount int32
@@ -887,8 +888,10 @@ func (s *Storage) ExtendMessageLease(ctx context.Context, queueName string, mess
 			return err
 		}
 		metrics.IncrementLeaseRenewals(queueName, "success")
+		remainingTimeMs = max(newLeaseRuntime.LeaseExpiry-s.nowMs(), 0)
 		return nil
 	})
+	return remainingTimeMs, err
 }
 
 // HeartbeatMessage updates the heartbeat for a message.

--- a/pkg/repository/postgres/queues.go
+++ b/pkg/repository/postgres/queues.go
@@ -12,24 +12,42 @@ import (
 	"github.com/adrien19/chronoqueue/internal/domainerror"
 )
 
+const lockQueuesForRelationshipMutation = `LOCK TABLE cq_queues IN SHARE ROW EXCLUSIVE MODE`
+
 func (s *Storage) CreateQueue(ctx context.Context, queue *queuepb.Queue) error {
 	queueBytes, err := s.Serializer.MarshalQueue(queue)
 	if err != nil {
 		return fmt.Errorf("marshal queue: %w", err)
 	}
 
-	query := s.ph(`INSERT INTO cq_queues (name, metadata_pb, state_counts, created_at, updated_at) VALUES (?, ?, '{}', ?, ?)`)
-	now := s.nowMs()
-	_, err = s.DB.ExecContext(ctx, query, queue.Name, queueBytes, now, now)
-	if err != nil {
-		var pqErr *pq.Error
-		if errors.As(err, &pqErr) && pqErr.Code == "23505" {
-			return domainerror.New(domainerror.AlreadyExists, fmt.Sprintf("queue %q already exists", queue.Name), err)
+	return s.WithTransaction(ctx, nil, func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, lockQueuesForRelationshipMutation); err != nil {
+			return fmt.Errorf("lock queues for creation: %w", err)
 		}
-		return fmt.Errorf("insert queue: %w", err)
-	}
 
-	return nil
+		metadata := queue.GetMetadata()
+		if dlqName := metadata.GetDeadLetterQueueName(); dlqName != "" && !metadata.GetAutoCreateDlq() {
+			var exists int
+			if err := tx.QueryRowContext(ctx, `SELECT 1 FROM cq_queues WHERE name = $1`, dlqName).Scan(&exists); err != nil {
+				if err == sql.ErrNoRows {
+					return domainerror.New(domainerror.NotFound, fmt.Sprintf("dead letter queue %q not found", dlqName), err)
+				}
+				return fmt.Errorf("query dead letter queue: %w", err)
+			}
+		}
+
+		query := s.ph(`INSERT INTO cq_queues (name, metadata_pb, state_counts, created_at, updated_at) VALUES (?, ?, '{}', ?, ?)`)
+		now := s.nowMs()
+		if _, err := tx.ExecContext(ctx, query, queue.Name, queueBytes, now, now); err != nil {
+			var pqErr *pq.Error
+			if errors.As(err, &pqErr) && pqErr.Code == "23505" {
+				return domainerror.New(domainerror.AlreadyExists, fmt.Sprintf("queue %q already exists", queue.Name), err)
+			}
+			return fmt.Errorf("insert queue: %w", err)
+		}
+
+		return nil
+	})
 }
 
 // GetQueue retrieves a queue by name.
@@ -106,21 +124,48 @@ func (s *Storage) ListQueuesWithPrefix(ctx context.Context, prefix string) ([]*q
 
 // DeleteQueue deletes a queue.
 func (s *Storage) DeleteQueue(ctx context.Context, name string) error {
-	query := s.ph(`DELETE FROM cq_queues WHERE name = ?`)
-	result, err := s.DB.ExecContext(ctx, query, name)
-	if err != nil {
-		return fmt.Errorf("delete queue: %w", err)
-	}
+	return s.WithTransaction(ctx, nil, func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, lockQueuesForRelationshipMutation); err != nil {
+			return fmt.Errorf("lock queues for deletion: %w", err)
+		}
+		var exists int
+		if err := tx.QueryRowContext(ctx, `SELECT 1 FROM cq_queues WHERE name = $1`, name).Scan(&exists); err != nil {
+			if err == sql.ErrNoRows {
+				return domainerror.New(domainerror.NotFound, fmt.Sprintf("queue %q not found", name), err)
+			}
+			return fmt.Errorf("query queue for deletion: %w", err)
+		}
 
-	rows, err := result.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("get rows affected: %w", err)
-	}
-	if rows == 0 {
-		return domainerror.New(domainerror.NotFound, fmt.Sprintf("queue %q not found", name), nil)
-	}
+		rows, err := tx.QueryContext(ctx, `SELECT metadata_pb FROM cq_queues WHERE name <> $1`, name)
+		if err != nil {
+			return fmt.Errorf("query queue references: %w", err)
+		}
+		defer func() { _ = rows.Close() }()
+		for rows.Next() {
+			var queueBytes []byte
+			if err := rows.Scan(&queueBytes); err != nil {
+				return fmt.Errorf("scan queue reference: %w", err)
+			}
+			queue, err := s.Serializer.UnmarshalQueue(queueBytes)
+			if err != nil {
+				return fmt.Errorf("unmarshal queue reference: %w", err)
+			}
+			if queue.GetMetadata().GetDeadLetterQueueName() == name {
+				return domainerror.New(domainerror.FailedPrecondition, fmt.Sprintf("queue %q is referenced as a dead letter queue by %q", name, queue.GetName()), nil)
+			}
+		}
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("iterate queue references: %w", err)
+		}
+		if err := rows.Close(); err != nil {
+			return fmt.Errorf("close queue references: %w", err)
+		}
 
-	return nil
+		if _, err := tx.ExecContext(ctx, `DELETE FROM cq_queues WHERE name = $1`, name); err != nil {
+			return fmt.Errorf("delete queue: %w", err)
+		}
+		return nil
+	})
 }
 
 // EnqueueMessage adds a message to a queue.

--- a/pkg/repository/postgres/reclaim_integration_test.go
+++ b/pkg/repository/postgres/reclaim_integration_test.go
@@ -42,66 +42,64 @@ func TestReclaimExpiredMessage_AtomicAcrossPostgresInstances(t *testing.T) {
 
 	first := newPostgresReclaimTestStorage(t, ctx, dsn)
 	second := newPostgresReclaimTestStorage(t, ctx, dsn)
-	require.NoError(t, first.CreateQueue(ctx, &queuepb.Queue{Name: "protected-dlq", Metadata: &queuepb.QueueMetadata{}}))
-	require.NoError(t, first.CreateQueue(ctx, &queuepb.Queue{Name: "protected-source", Metadata: &queuepb.QueueMetadata{DeadLetterQueueName: "protected-dlq"}}))
-	require.ErrorContains(t, first.DeleteQueue(ctx, "protected-dlq"), "referenced as a dead letter queue")
-	require.NoError(t, first.DeleteQueue(ctx, "protected-source"))
-	require.NoError(t, first.DeleteQueue(ctx, "protected-dlq"))
+	t.Run("rejects deletion of referenced DLQ", func(t *testing.T) {
+		require.NoError(t, first.CreateQueue(ctx, &queuepb.Queue{Name: "protected-dlq", Metadata: &queuepb.QueueMetadata{}}))
+		require.NoError(t, first.CreateQueue(ctx, &queuepb.Queue{Name: "protected-source", Metadata: &queuepb.QueueMetadata{DeadLetterQueueName: "protected-dlq"}}))
+		require.ErrorContains(t, first.DeleteQueue(ctx, "protected-dlq"), "referenced as a dead letter queue")
+		require.NoError(t, first.DeleteQueue(ctx, "protected-source"))
+		require.NoError(t, first.DeleteQueue(ctx, "protected-dlq"))
+	})
 
-	require.NoError(t, first.CreateQueue(ctx, &queuepb.Queue{Name: "concurrent-dlq", Metadata: &queuepb.QueueMetadata{}}))
-	deleteTx, err := first.DB.BeginTx(ctx, nil)
-	require.NoError(t, err)
-	_, err = deleteTx.ExecContext(ctx, lockQueuesForRelationshipMutation)
-	require.NoError(t, err)
-	_, err = deleteTx.ExecContext(ctx, `DELETE FROM cq_queues WHERE name = $1`, "concurrent-dlq")
-	require.NoError(t, err)
-	createErr := make(chan error, 1)
-	go func() {
-		createErr <- second.CreateQueue(ctx, &queuepb.Queue{
-			Name: "concurrent-source",
-			Metadata: &queuepb.QueueMetadata{
-				DeadLetterQueueName: "concurrent-dlq",
-			},
-		})
-	}()
-	require.NoError(t, deleteTx.Commit())
-	require.ErrorContains(t, <-createErr, `dead letter queue "concurrent-dlq" not found`)
-	_, err = first.GetQueue(ctx, "concurrent-source")
-	require.ErrorContains(t, err, `queue "concurrent-source" not found`)
+	t.Run("serializes dependent creation with DLQ deletion", func(t *testing.T) {
+		require.NoError(t, first.CreateQueue(ctx, &queuepb.Queue{Name: "concurrent-dlq", Metadata: &queuepb.QueueMetadata{}}))
+		deleteTx, err := first.DB.BeginTx(ctx, nil)
+		require.NoError(t, err)
+		_, err = deleteTx.ExecContext(ctx, lockQueuesForRelationshipMutation)
+		require.NoError(t, err)
+		_, err = deleteTx.ExecContext(ctx, `DELETE FROM cq_queues WHERE name = $1`, "concurrent-dlq")
+		require.NoError(t, err)
+		createErr := make(chan error, 1)
+		go func() {
+			createErr <- second.CreateQueue(ctx, &queuepb.Queue{Name: "concurrent-source", Metadata: &queuepb.QueueMetadata{DeadLetterQueueName: "concurrent-dlq"}})
+		}()
+		require.NoError(t, deleteTx.Commit())
+		require.ErrorContains(t, <-createErr, `dead letter queue "concurrent-dlq" not found`)
+		_, err = first.GetQueue(ctx, "concurrent-source")
+		require.ErrorContains(t, err, `queue "concurrent-source" not found`)
+	})
 
-	require.NoError(t, first.CreateQueue(ctx, &queuepb.Queue{Name: "scheduled-cas", Metadata: &queuepb.QueueMetadata{}}))
-	dueMessage := postgresReclaimTestMessage("scheduled-once", 1, 1)
-	dueMessage.Metadata.State = messagepb.Message_Metadata_INVISIBLE
-	dueMessage.Metadata.ScheduledTime = timestamppb.New(time.Now().Add(-time.Minute))
-	require.NoError(t, first.EnqueueMessage(ctx, "scheduled-cas", dueMessage))
-	_, err = first.DB.ExecContext(ctx, `UPDATE cq_queues SET state_counts = '{"invisible":1}' WHERE name = $1`, "scheduled-cas")
-	require.NoError(t, err)
-	schedulers := []*background.SchedulerService{
-		background.NewSchedulerService(first.BaseSQL, time.Second),
-		background.NewSchedulerService(second.BaseSQL, time.Second),
-	}
-	startSchedulers := make(chan struct{})
-	schedulerErrs := make(chan error, len(schedulers))
-	var schedulerWG sync.WaitGroup
-	for _, scheduler := range schedulers {
-		schedulerWG.Add(1)
-		go func(scheduler *background.SchedulerService) {
-			defer schedulerWG.Done()
-			<-startSchedulers
-			schedulerErrs <- scheduler.RunOnce(ctx)
-		}(scheduler)
-	}
-	close(startSchedulers)
-	schedulerWG.Wait()
-	close(schedulerErrs)
-	for schedulerErr := range schedulerErrs {
-		require.NoError(t, schedulerErr)
-	}
-	var invisibleCount, pendingCount int64
-	err = first.DB.QueryRowContext(ctx, `SELECT COALESCE((state_counts->>'invisible')::BIGINT, 0), COALESCE((state_counts->>'pending')::BIGINT, 0) FROM cq_queues WHERE name = $1`, "scheduled-cas").Scan(&invisibleCount, &pendingCount)
-	require.NoError(t, err)
-	require.Zero(t, invisibleCount)
-	require.EqualValues(t, 1, pendingCount)
+	t.Run("promotes a scheduled message once across schedulers", func(t *testing.T) {
+		require.NoError(t, first.CreateQueue(ctx, &queuepb.Queue{Name: "scheduled-cas", Metadata: &queuepb.QueueMetadata{}}))
+		dueMessage := postgresReclaimTestMessage("scheduled-once", 1, 1)
+		dueMessage.Metadata.State = messagepb.Message_Metadata_INVISIBLE
+		dueMessage.Metadata.ScheduledTime = timestamppb.New(time.Now().Add(-time.Minute))
+		require.NoError(t, first.EnqueueMessage(ctx, "scheduled-cas", dueMessage))
+		_, err := first.DB.ExecContext(ctx, `UPDATE cq_queues SET state_counts = '{"invisible":1}' WHERE name = $1`, "scheduled-cas")
+		require.NoError(t, err)
+		schedulers := []*background.SchedulerService{background.NewSchedulerService(first.BaseSQL, time.Second), background.NewSchedulerService(second.BaseSQL, time.Second)}
+		startSchedulers := make(chan struct{})
+		schedulerErrs := make(chan error, len(schedulers))
+		var schedulerWG sync.WaitGroup
+		for _, scheduler := range schedulers {
+			schedulerWG.Add(1)
+			go func(scheduler *background.SchedulerService) {
+				defer schedulerWG.Done()
+				<-startSchedulers
+				schedulerErrs <- scheduler.RunOnce(ctx)
+			}(scheduler)
+		}
+		close(startSchedulers)
+		schedulerWG.Wait()
+		close(schedulerErrs)
+		for schedulerErr := range schedulerErrs {
+			require.NoError(t, schedulerErr)
+		}
+		var invisibleCount, pendingCount int64
+		err = first.DB.QueryRowContext(ctx, `SELECT COALESCE((state_counts->>'invisible')::BIGINT, 0), COALESCE((state_counts->>'pending')::BIGINT, 0) FROM cq_queues WHERE name = $1`, "scheduled-cas").Scan(&invisibleCount, &pendingCount)
+		require.NoError(t, err)
+		require.Zero(t, invisibleCount)
+		require.EqualValues(t, 1, pendingCount)
+	})
 
 	queueName := "reclaim-fencing"
 	require.NoError(t, first.CreateQueue(ctx, &queuepb.Queue{Name: queueName, Metadata: &queuepb.QueueMetadata{}}))

--- a/pkg/repository/postgres/reclaim_integration_test.go
+++ b/pkg/repository/postgres/reclaim_integration_test.go
@@ -14,12 +14,14 @@ import (
 	postgrescontainer "github.com/testcontainers/testcontainers-go/modules/postgres"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	commonpb "github.com/adrien19/chronoqueue/api/common/v1"
 	messagepb "github.com/adrien19/chronoqueue/api/message/v1"
 	queuepb "github.com/adrien19/chronoqueue/api/queue/v1"
 	"github.com/adrien19/chronoqueue/internal/encryption/keymanager"
 	"github.com/adrien19/chronoqueue/pkg/log"
+	"github.com/adrien19/chronoqueue/pkg/repository/sql/background"
 )
 
 func TestReclaimExpiredMessage_AtomicAcrossPostgresInstances(t *testing.T) {
@@ -40,6 +42,67 @@ func TestReclaimExpiredMessage_AtomicAcrossPostgresInstances(t *testing.T) {
 
 	first := newPostgresReclaimTestStorage(t, ctx, dsn)
 	second := newPostgresReclaimTestStorage(t, ctx, dsn)
+	require.NoError(t, first.CreateQueue(ctx, &queuepb.Queue{Name: "protected-dlq", Metadata: &queuepb.QueueMetadata{}}))
+	require.NoError(t, first.CreateQueue(ctx, &queuepb.Queue{Name: "protected-source", Metadata: &queuepb.QueueMetadata{DeadLetterQueueName: "protected-dlq"}}))
+	require.ErrorContains(t, first.DeleteQueue(ctx, "protected-dlq"), "referenced as a dead letter queue")
+	require.NoError(t, first.DeleteQueue(ctx, "protected-source"))
+	require.NoError(t, first.DeleteQueue(ctx, "protected-dlq"))
+
+	require.NoError(t, first.CreateQueue(ctx, &queuepb.Queue{Name: "concurrent-dlq", Metadata: &queuepb.QueueMetadata{}}))
+	deleteTx, err := first.DB.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	_, err = deleteTx.ExecContext(ctx, lockQueuesForRelationshipMutation)
+	require.NoError(t, err)
+	_, err = deleteTx.ExecContext(ctx, `DELETE FROM cq_queues WHERE name = $1`, "concurrent-dlq")
+	require.NoError(t, err)
+	createErr := make(chan error, 1)
+	go func() {
+		createErr <- second.CreateQueue(ctx, &queuepb.Queue{
+			Name: "concurrent-source",
+			Metadata: &queuepb.QueueMetadata{
+				DeadLetterQueueName: "concurrent-dlq",
+			},
+		})
+	}()
+	require.NoError(t, deleteTx.Commit())
+	require.ErrorContains(t, <-createErr, `dead letter queue "concurrent-dlq" not found`)
+	_, err = first.GetQueue(ctx, "concurrent-source")
+	require.ErrorContains(t, err, `queue "concurrent-source" not found`)
+
+	require.NoError(t, first.CreateQueue(ctx, &queuepb.Queue{Name: "scheduled-cas", Metadata: &queuepb.QueueMetadata{}}))
+	dueMessage := postgresReclaimTestMessage("scheduled-once", 1, 1)
+	dueMessage.Metadata.State = messagepb.Message_Metadata_INVISIBLE
+	dueMessage.Metadata.ScheduledTime = timestamppb.New(time.Now().Add(-time.Minute))
+	require.NoError(t, first.EnqueueMessage(ctx, "scheduled-cas", dueMessage))
+	_, err = first.DB.ExecContext(ctx, `UPDATE cq_queues SET state_counts = '{"invisible":1}' WHERE name = $1`, "scheduled-cas")
+	require.NoError(t, err)
+	schedulers := []*background.SchedulerService{
+		background.NewSchedulerService(first.BaseSQL, time.Second),
+		background.NewSchedulerService(second.BaseSQL, time.Second),
+	}
+	startSchedulers := make(chan struct{})
+	schedulerErrs := make(chan error, len(schedulers))
+	var schedulerWG sync.WaitGroup
+	for _, scheduler := range schedulers {
+		schedulerWG.Add(1)
+		go func(scheduler *background.SchedulerService) {
+			defer schedulerWG.Done()
+			<-startSchedulers
+			schedulerErrs <- scheduler.RunOnce(ctx)
+		}(scheduler)
+	}
+	close(startSchedulers)
+	schedulerWG.Wait()
+	close(schedulerErrs)
+	for schedulerErr := range schedulerErrs {
+		require.NoError(t, schedulerErr)
+	}
+	var invisibleCount, pendingCount int64
+	err = first.DB.QueryRowContext(ctx, `SELECT COALESCE((state_counts->>'invisible')::BIGINT, 0), COALESCE((state_counts->>'pending')::BIGINT, 0) FROM cq_queues WHERE name = $1`, "scheduled-cas").Scan(&invisibleCount, &pendingCount)
+	require.NoError(t, err)
+	require.Zero(t, invisibleCount)
+	require.EqualValues(t, 1, pendingCount)
+
 	queueName := "reclaim-fencing"
 	require.NoError(t, first.CreateQueue(ctx, &queuepb.Queue{Name: queueName, Metadata: &queuepb.QueueMetadata{}}))
 	require.NoError(t, first.EnqueueMessage(ctx, queueName, postgresReclaimTestMessage("finite", 2, 2)))
@@ -149,7 +212,8 @@ func TestWorkerMutations_RequireActiveOwnershipAcrossPostgresInstances(t *testin
 			return err
 		},
 		"renew": func(ctx context.Context, storage *Storage, queue, attempt, worker string) error {
-			return storage.ExtendMessageLease(ctx, queue, "renew", attempt, worker, 1_000)
+			_, err := storage.ExtendMessageLease(ctx, queue, "renew", attempt, worker, 1_000)
+			return err
 		},
 	}
 

--- a/pkg/repository/sql/background/metrics_reporter_sqlite_test.go
+++ b/pkg/repository/sql/background/metrics_reporter_sqlite_test.go
@@ -21,8 +21,8 @@ func TestMetricsReporterEmitsDatabaseAndDLQGauges(t *testing.T) {
 	ctx := context.Background()
 	storage := newTestStorage(t)
 	t.Cleanup(func() { require.NoError(t, storage.Close()) })
-	require.NoError(t, storage.CreateQueue(ctx, &queuepb.Queue{Name: "source", Metadata: &queuepb.QueueMetadata{DeadLetterQueueName: "source-dlq"}}))
 	require.NoError(t, storage.CreateQueue(ctx, &queuepb.Queue{Name: "source-dlq", Metadata: &queuepb.QueueMetadata{}}))
+	require.NoError(t, storage.CreateQueue(ctx, &queuepb.Queue{Name: "source", Metadata: &queuepb.QueueMetadata{DeadLetterQueueName: "source-dlq"}}))
 
 	registry := metrics.NewMetricsRegistry()
 	reporter := NewMetricsReporterService(storage.BaseSQL, time.Second)
@@ -57,6 +57,7 @@ func TestMetricsReporterRecordsMetadataFailureWithoutAdvancingLastReportedAt(t *
 	ctx := context.Background()
 	storage := newTestStorage(t)
 	t.Cleanup(func() { require.NoError(t, storage.Close()) })
+	require.NoError(t, storage.CreateQueue(ctx, &queuepb.Queue{Name: "source-dlq", Metadata: &queuepb.QueueMetadata{}}))
 	require.NoError(t, storage.CreateQueue(ctx, &queuepb.Queue{Name: "source", Metadata: &queuepb.QueueMetadata{DeadLetterQueueName: "source-dlq"}}))
 	_, err := storage.DB.ExecContext(ctx, `UPDATE cq_queues SET metadata_pb = ? WHERE name = ?`, []byte("invalid"), "source")
 	require.NoError(t, err)
@@ -76,10 +77,10 @@ func TestMetricsReporterReportsSharedDLQOnce(t *testing.T) {
 	ctx := context.Background()
 	storage := newTestStorage(t)
 	t.Cleanup(func() { require.NoError(t, storage.Close()) })
+	require.NoError(t, storage.CreateQueue(ctx, &queuepb.Queue{Name: "shared-dlq", Metadata: &queuepb.QueueMetadata{}}))
 	for _, source := range []string{"source-a", "source-b"} {
 		require.NoError(t, storage.CreateQueue(ctx, &queuepb.Queue{Name: source, Metadata: &queuepb.QueueMetadata{DeadLetterQueueName: "shared-dlq"}}))
 	}
-	require.NoError(t, storage.CreateQueue(ctx, &queuepb.Queue{Name: "shared-dlq", Metadata: &queuepb.QueueMetadata{}}))
 
 	registry := metrics.NewMetricsRegistry()
 	NewMetricsReporterService(storage.BaseSQL, time.Second).reportMetrics(ctx)
@@ -99,8 +100,8 @@ func TestMetricsReporterDLQCountFailureDoesNotRecordSuccess(t *testing.T) {
 	ctx := context.Background()
 	storage := newTestStorage(t)
 	t.Cleanup(func() { require.NoError(t, storage.Close()) })
-	require.NoError(t, storage.CreateQueue(ctx, &queuepb.Queue{Name: "source", Metadata: &queuepb.QueueMetadata{DeadLetterQueueName: "source-dlq"}}))
 	require.NoError(t, storage.CreateQueue(ctx, &queuepb.Queue{Name: "source-dlq", Metadata: &queuepb.QueueMetadata{}}))
+	require.NoError(t, storage.CreateQueue(ctx, &queuepb.Queue{Name: "source", Metadata: &queuepb.QueueMetadata{DeadLetterQueueName: "source-dlq"}}))
 	_, err := storage.DB.ExecContext(ctx, "DROP TABLE cq_messages")
 	require.NoError(t, err)
 	registry := metrics.NewMetricsRegistry()

--- a/pkg/repository/sql/background/reclaim_metrics_sqlite_test.go
+++ b/pkg/repository/sql/background/reclaim_metrics_sqlite_test.go
@@ -41,10 +41,10 @@ func TestReclaimMetricsReflectPersistedExpiryCause(t *testing.T) {
 			storage := newTestStorage(t)
 			t.Cleanup(func() { require.NoError(t, storage.Close()) })
 			queueName := "reclaim-" + strings.ReplaceAll(tt.name, " ", "-")
-			require.NoError(t, storage.CreateQueue(ctx, &queuepb.Queue{Name: queueName, Metadata: &queuepb.QueueMetadata{DeadLetterQueueName: tt.dlqTarget}}))
 			if tt.dlqTarget != "" {
 				require.NoError(t, storage.CreateQueue(ctx, &queuepb.Queue{Name: tt.dlqTarget, Metadata: &queuepb.QueueMetadata{}}))
 			}
+			require.NoError(t, storage.CreateQueue(ctx, &queuepb.Queue{Name: queueName, Metadata: &queuepb.QueueMetadata{DeadLetterQueueName: tt.dlqTarget}}))
 			attemptsLeft := int32(2)
 			if tt.transitionsToErrored {
 				attemptsLeft = 1

--- a/pkg/repository/sql/background/scheduler.go
+++ b/pkg/repository/sql/background/scheduler.go
@@ -72,6 +72,11 @@ func (s *SchedulerService) Stop() {
 	close(s.stopChan)
 }
 
+// RunOnce processes due messages once.
+func (s *SchedulerService) RunOnce(ctx context.Context) error {
+	return s.processScheduledMessages(ctx)
+}
+
 // scheduledMessage holds data for a message that needs activation
 type scheduledMessage struct {
 	id        int64
@@ -116,12 +121,16 @@ func (s *SchedulerService) processScheduledMessages(ctx context.Context) error {
 		msg.message.Metadata.State = messagepb.Message_Metadata_PENDING
 
 		// Update state in transaction
-		if err := s.activateMessage(ctx, msg.id, msg.queueName, msg.messageID, msg.message, oldState); err != nil {
+		activatedMessage, err := s.activateMessage(ctx, msg.id, msg.queueName, msg.messageID, msg.message, oldState, nowMs)
+		if err != nil {
 			s.base.Logger.ErrorWithFields(
 				"Failed to activate scheduled message",
 				"message_id", msg.messageID,
 				"error", err,
 			)
+			continue
+		}
+		if !activatedMessage {
 			continue
 		}
 
@@ -213,8 +222,10 @@ func (s *SchedulerService) activateMessage(
 	messageID string,
 	message *messagepb.Message,
 	oldState messagepb.Message_Metadata_State,
-) error {
-	return s.base.WithTransaction(ctx, &sqlbase.TxOptions{Timeout: 5 * time.Second}, func(tx *sql.Tx) error {
+	nowMs int64,
+) (bool, error) {
+	activated := false
+	err := s.base.WithTransaction(ctx, &sqlbase.TxOptions{Timeout: 5 * time.Second}, func(tx *sql.Tx) error {
 		// Marshal updated message
 		metadataBytes, err := s.base.Serializer.MarshalMessage(message)
 		if err != nil {
@@ -227,28 +238,44 @@ func (s *SchedulerService) activateMessage(
 			SET state = %s,
 			    metadata_pb = %s,
 			    updated_at = %s
-			WHERE id = %s
+			WHERE id = %s AND state = %s AND scheduled_at <= %s
 		`, s.base.Dialect.Placeholder(1),
 			s.base.Dialect.Placeholder(2),
 			s.base.Dialect.Placeholder(3),
-			s.base.Dialect.Placeholder(4))
+			s.base.Dialect.Placeholder(4),
+			s.base.Dialect.Placeholder(5),
+			s.base.Dialect.Placeholder(6))
 
-		_, err = tx.ExecContext(
+		result, err := tx.ExecContext(
 			ctx, updateQuery,
 			int(message.GetMetadata().GetState()),
 			metadataBytes,
 			s.base.Clock.NowMs(),
 			id,
+			int(messagepb.Message_Metadata_INVISIBLE),
+			nowMs,
 		)
 		if err != nil {
 			return fmt.Errorf("update message: %w", err)
+		}
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("get activated message rows: %w", err)
+		}
+		if rows == 0 {
+			return nil
+		}
+		if rows != 1 {
+			return fmt.Errorf("activate message: expected one row, updated %d", rows)
 		}
 
 		// Update state counters
 		if err := s.base.StateManager.UpdateCounters(ctx, tx, queueName, oldState, message.GetMetadata().GetState()); err != nil {
 			return fmt.Errorf("update counters: %w", err)
 		}
+		activated = true
 
 		return nil
 	})
+	return activated, err
 }

--- a/pkg/repository/sql/background/scheduler_test.go
+++ b/pkg/repository/sql/background/scheduler_test.go
@@ -1,0 +1,53 @@
+package background
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	messagepb "github.com/adrien19/chronoqueue/api/message/v1"
+	queuepb "github.com/adrien19/chronoqueue/api/queue/v1"
+)
+
+func TestSchedulerActivationIsCompareAndSet(t *testing.T) {
+	ctx := context.Background()
+	storage := newTestStorage(t)
+	t.Cleanup(func() { require.NoError(t, storage.Close()) })
+
+	queueName := "scheduled-cas"
+	require.NoError(t, storage.CreateQueue(ctx, &queuepb.Queue{Name: queueName, Metadata: &queuepb.QueueMetadata{}}))
+	due := time.Now().Add(-time.Minute)
+	message := &messagepb.Message{
+		MessageId: "due-message",
+		Metadata: &messagepb.Message_Metadata{
+			State:         messagepb.Message_Metadata_INVISIBLE,
+			ScheduledTime: timestamppb.New(due),
+		},
+	}
+	require.NoError(t, storage.EnqueueMessage(ctx, queueName, message))
+	_, err := storage.DB.ExecContext(ctx, `UPDATE cq_queues SET state_counts = '{"invisible":1}' WHERE name = ?`, queueName)
+	require.NoError(t, err)
+
+	service := NewSchedulerService(storage.BaseSQL, time.Second)
+	candidates, err := service.collectScheduledMessages(ctx, storage.Clock.NowMs())
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	candidate := candidates[0]
+	candidate.message.Metadata.State = messagepb.Message_Metadata_PENDING
+
+	activated, err := service.activateMessage(ctx, candidate.id, candidate.queueName, candidate.messageID, candidate.message, messagepb.Message_Metadata_INVISIBLE, storage.Clock.NowMs())
+	require.NoError(t, err)
+	require.True(t, activated)
+
+	activated, err = service.activateMessage(ctx, candidate.id, candidate.queueName, candidate.messageID, candidate.message, messagepb.Message_Metadata_INVISIBLE, storage.Clock.NowMs())
+	require.NoError(t, err)
+	require.False(t, activated)
+
+	counts, err := storage.StateManager.GetStateCounts(ctx, storage.DB, queueName)
+	require.NoError(t, err)
+	require.EqualValues(t, 0, counts["invisible"])
+	require.EqualValues(t, 1, counts["pending"])
+}

--- a/pkg/repository/sql/lease.go
+++ b/pkg/repository/sql/lease.go
@@ -65,6 +65,7 @@ func (lrc *LeaseRuntimeCalculator) CalculateLeaseRuntimeWithDuration(policy *com
 // Returns updated lease runtime or error if max extension reached.
 func (lrc *LeaseRuntimeCalculator) ExtendLease(
 	policy *commonpb.LeasePolicy,
+	currentLeaseExpiry int64,
 	currentExtensionUsed int64,
 	requestedExtensionMs int64,
 ) (*LeaseRuntime, error) {
@@ -87,11 +88,10 @@ func (lrc *LeaseRuntimeCalculator) ExtendLease(
 		actualExtensionMs = remainingExtensionMs
 	}
 
-	nowMs := lrc.clock.NowMs()
 	newExtensionUsed := currentExtensionUsed + actualExtensionMs
 
 	return &LeaseRuntime{
-		LeaseExpiry:        nowMs + actualExtensionMs,
+		LeaseExpiry:        currentLeaseExpiry + actualExtensionMs,
 		LeaseExtensionUsed: newExtensionUsed,
 	}, nil
 }

--- a/pkg/repository/sql/lease_test.go
+++ b/pkg/repository/sql/lease_test.go
@@ -96,3 +96,18 @@ func TestLeaseRuntimeCalculator_RequestedDurationOverridesPolicy(t *testing.T) {
 	assert.EqualValues(t, 45*time.Second/time.Millisecond, runtime.LeaseExpiry-runtime.LeaseStartedAt)
 	assert.EqualValues(t, 10*time.Second/time.Millisecond, runtime.HeartbeatExpiry-runtime.LastHeartbeatAt)
 }
+
+func TestLeaseRuntimeCalculator_ExtendLeaseAddsToCurrentExpiryAndCapsExtension(t *testing.T) {
+	calculator := NewLeaseRuntimeCalculator(NewClock())
+	policy := &commonpb.LeasePolicy{
+		MaxExtension: durationpb.New(5 * time.Second),
+		ExtendStep:   durationpb.New(time.Second),
+	}
+	currentExpiry := time.Now().Add(time.Minute).UnixMilli()
+
+	runtime, err := calculator.ExtendLease(policy, currentExpiry, 2_000, 10_000)
+
+	assert.NoError(t, err)
+	assert.Equal(t, currentExpiry+3_000, runtime.LeaseExpiry)
+	assert.EqualValues(t, 5_000, runtime.LeaseExtensionUsed)
+}

--- a/pkg/repository/sqlite/messages.go
+++ b/pkg/repository/sqlite/messages.go
@@ -825,18 +825,19 @@ func (s *Storage) ExtendMessageLease(ctx context.Context, queueName string, mess
 	var remainingTimeMs int64
 	err := s.WithTransaction(ctx, nil, func(tx *sql.Tx) error {
 		var messageBytes []byte
+		var currentLeaseExpiry int64
 		var leaseExtensionUsed int64
 		var currentRenewalCount int32
 		nowMs := s.nowMs()
 		query := `
-			SELECT metadata_pb, lease_extension_used, lease_renewal_count
+			SELECT metadata_pb, lease_expiry, lease_extension_used, lease_renewal_count
 			FROM cq_messages
 			WHERE queue_name = ? AND message_id = ? AND state = ?
 			  AND current_attempt_id = ? AND current_worker_id = ?
 			  AND lease_expiry > ?
 			  AND (heartbeat_expiry IS NULL OR heartbeat_expiry <= 0 OR heartbeat_expiry > ?)
 			  AND deleted_at IS NULL`
-		err := tx.QueryRowContext(ctx, query, queueName, messageId, messagepb.Message_Metadata_RUNNING, attemptId, workerId, nowMs, nowMs).Scan(&messageBytes, &leaseExtensionUsed, &currentRenewalCount)
+		err := tx.QueryRowContext(ctx, query, queueName, messageId, messagepb.Message_Metadata_RUNNING, attemptId, workerId, nowMs, nowMs).Scan(&messageBytes, &currentLeaseExpiry, &leaseExtensionUsed, &currentRenewalCount)
 		if err == sql.ErrNoRows {
 			return s.classifyOwnedMessageFailure(ctx, tx, queueName, messageId, attemptId, workerId, nowMs)
 		}
@@ -860,7 +861,7 @@ func (s *Storage) ExtendMessageLease(ctx context.Context, queueName string, mess
 		}
 
 		// Calculate new lease
-		newLeaseRuntime, err := s.LeaseRuntime.ExtendLease(leasePolicy, leaseExtensionUsed, extensionMs)
+		newLeaseRuntime, err := s.LeaseRuntime.ExtendLease(leasePolicy, currentLeaseExpiry, leaseExtensionUsed, extensionMs)
 		if err != nil {
 			return domainerror.New(domainerror.FailedPrecondition, "maximum lease extension reached", err)
 		}

--- a/pkg/repository/sqlite/messages.go
+++ b/pkg/repository/sqlite/messages.go
@@ -821,8 +821,9 @@ func (s *Storage) CancelMessage(ctx context.Context, queueName string, messageId
 }
 
 // ExtendMessageLease extends the lease on a message
-func (s *Storage) ExtendMessageLease(ctx context.Context, queueName string, messageId string, attemptId string, workerId string, extensionMs int64) error {
-	return s.WithTransaction(ctx, nil, func(tx *sql.Tx) error {
+func (s *Storage) ExtendMessageLease(ctx context.Context, queueName string, messageId string, attemptId string, workerId string, extensionMs int64) (int64, error) {
+	var remainingTimeMs int64
+	err := s.WithTransaction(ctx, nil, func(tx *sql.Tx) error {
 		var messageBytes []byte
 		var leaseExtensionUsed int64
 		var currentRenewalCount int32
@@ -892,8 +893,10 @@ func (s *Storage) ExtendMessageLease(ctx context.Context, queueName string, mess
 			return err
 		}
 		metrics.IncrementLeaseRenewals(queueName, "success")
+		remainingTimeMs = max(newLeaseRuntime.LeaseExpiry-s.nowMs(), 0)
 		return nil
 	})
+	return remainingTimeMs, err
 }
 
 // HeartbeatMessage updates the heartbeat for a message

--- a/pkg/repository/sqlite/ownership_test.go
+++ b/pkg/repository/sqlite/ownership_test.go
@@ -38,8 +38,8 @@ func TestExtendMessageLease_ReturnsPolicyCappedRemainingTime(t *testing.T) {
 	remainingMs, err := storage.ExtendMessageLease(ctx, "owned", message.GetMessageId(), "attempt", "worker", int64((10 * time.Second).Milliseconds()))
 	require.NoError(t, err)
 	require.Positive(t, remainingMs)
-	require.LessOrEqual(t, remainingMs, int64((5 * time.Second).Milliseconds()))
-	require.Greater(t, remainingMs, int64((4 * time.Second).Milliseconds()))
+	require.LessOrEqual(t, remainingMs, int64((65 * time.Second).Milliseconds()))
+	require.Greater(t, remainingMs, int64((64 * time.Second).Milliseconds()))
 }
 
 func TestWorkerMutations_RequireActiveOwnership(t *testing.T) {

--- a/pkg/repository/sqlite/ownership_test.go
+++ b/pkg/repository/sqlite/ownership_test.go
@@ -7,15 +7,40 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
 
+	commonpb "github.com/adrien19/chronoqueue/api/common/v1"
 	messagepb "github.com/adrien19/chronoqueue/api/message/v1"
 	queuepb "github.com/adrien19/chronoqueue/api/queue/v1"
 	"github.com/adrien19/chronoqueue/internal/domainerror"
 )
+
+func TestExtendMessageLease_ReturnsPolicyCappedRemainingTime(t *testing.T) {
+	ctx := context.Background()
+	storage := newReclaimTestStorage(t, ctx, filepath.Join(t.TempDir(), "renew-remaining.db"))
+	require.NoError(t, storage.CreateQueue(ctx, &queuepb.Queue{Name: "owned", Metadata: &queuepb.QueueMetadata{}}))
+	message := reclaimTestMessage("renew-capped", 1, 1)
+	message.Metadata.LeasePolicy = &commonpb.LeasePolicy{
+		BaseLease:    durationpb.New(time.Minute),
+		MaxExtension: durationpb.New(5 * time.Second),
+		ExtendStep:   durationpb.New(time.Second),
+	}
+	require.NoError(t, storage.EnqueueMessage(ctx, "owned", message))
+	claimed, err := storage.ClaimMessage(ctx, "owned", "worker", "attempt", "")
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+
+	remainingMs, err := storage.ExtendMessageLease(ctx, "owned", message.GetMessageId(), "attempt", "worker", int64((10 * time.Second).Milliseconds()))
+	require.NoError(t, err)
+	require.Positive(t, remainingMs)
+	require.LessOrEqual(t, remainingMs, int64((5 * time.Second).Milliseconds()))
+	require.Greater(t, remainingMs, int64((4 * time.Second).Milliseconds()))
+}
 
 func TestWorkerMutations_RequireActiveOwnership(t *testing.T) {
 	ctx := context.Background()
@@ -35,7 +60,8 @@ func TestWorkerMutations_RequireActiveOwnership(t *testing.T) {
 			return err
 		},
 		"renew": func(ctx context.Context, storage *Storage, queue, attempt, worker string) error {
-			return storage.ExtendMessageLease(ctx, queue, "renew", attempt, worker, 1_000)
+			_, err := storage.ExtendMessageLease(ctx, queue, "renew", attempt, worker, 1_000)
+			return err
 		},
 	}
 

--- a/pkg/repository/sqlite/queue_dlq_contract_test.go
+++ b/pkg/repository/sqlite/queue_dlq_contract_test.go
@@ -1,0 +1,93 @@
+//go:build sqlite && cgo
+
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	queuepb "github.com/adrien19/chronoqueue/api/queue/v1"
+	"github.com/adrien19/chronoqueue/internal/domainerror"
+)
+
+func TestDeleteQueue_RejectsReferencedDLQ(t *testing.T) {
+	ctx := context.Background()
+	storage := newReclaimTestStorage(t, ctx, filepath.Join(t.TempDir(), "referenced-dlq.db"))
+	require.NoError(t, storage.CreateQueue(ctx, &queuepb.Queue{Name: "orders-dlq", Metadata: &queuepb.QueueMetadata{}}))
+	require.NoError(t, storage.CreateQueue(ctx, &queuepb.Queue{
+		Name:     "orders",
+		Metadata: &queuepb.QueueMetadata{DeadLetterQueueName: "orders-dlq"},
+	}))
+
+	err := storage.DeleteQueue(ctx, "orders-dlq")
+	require.ErrorContains(t, err, "referenced as a dead letter queue")
+	require.Equal(t, codes.FailedPrecondition, status.Code(domainerror.ToGRPC(err)))
+
+	_, err = storage.GetQueue(ctx, "orders-dlq")
+	require.NoError(t, err)
+	require.NoError(t, storage.DeleteQueue(ctx, "orders"))
+	require.NoError(t, storage.DeleteQueue(ctx, "orders-dlq"))
+}
+
+func TestCreateQueue_ValidatesDLQInsideDeleteIntegrityBoundary(t *testing.T) {
+	ctx := context.Background()
+	databasePath := filepath.Join(t.TempDir(), "concurrent-dlq.db")
+	creator := newReclaimTestStorage(t, ctx, databasePath)
+	deleter := newReclaimTestStorage(t, ctx, databasePath)
+
+	err := creator.CreateQueue(ctx, &queuepb.Queue{
+		Name:     "missing-source",
+		Metadata: &queuepb.QueueMetadata{DeadLetterQueueName: "missing-dlq"},
+	})
+	require.ErrorContains(t, err, `dead letter queue "missing-dlq" not found`)
+	require.Equal(t, codes.NotFound, status.Code(domainerror.ToGRPC(err)))
+	_, err = creator.GetQueue(ctx, "missing-source")
+	require.Error(t, err)
+
+	for iteration := range 20 {
+		dlqName := fmt.Sprintf("concurrent-dlq-%d", iteration)
+		sourceName := fmt.Sprintf("concurrent-source-%d", iteration)
+		require.NoError(t, creator.CreateQueue(ctx, &queuepb.Queue{Name: dlqName, Metadata: &queuepb.QueueMetadata{}}))
+
+		start := make(chan struct{})
+		errs := make(chan error, 2)
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			errs <- creator.CreateQueue(ctx, &queuepb.Queue{
+				Name:     sourceName,
+				Metadata: &queuepb.QueueMetadata{DeadLetterQueueName: dlqName},
+			})
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			errs <- deleter.DeleteQueue(ctx, dlqName)
+		}()
+		close(start)
+		wg.Wait()
+		close(errs)
+		successes := 0
+		for operationErr := range errs {
+			if operationErr == nil {
+				successes++
+			}
+		}
+		require.Positive(t, successes)
+
+		_, sourceErr := creator.GetQueue(ctx, sourceName)
+		_, dlqErr := creator.GetQueue(ctx, dlqName)
+		if sourceErr == nil {
+			require.NoError(t, dlqErr, "dependent queue committed without its dead-letter queue")
+		}
+	}
+}

--- a/pkg/repository/sqlite/queues.go
+++ b/pkg/repository/sqlite/queues.go
@@ -16,17 +16,29 @@ func (s *Storage) CreateQueue(ctx context.Context, queue *queuepb.Queue) error {
 		return fmt.Errorf("marshal queue: %w", err)
 	}
 
-	query := `INSERT INTO cq_queues (name, metadata_pb, created_at, updated_at) VALUES (?, ?, ?, ?)`
-	nowMs := s.nowMs()
-	_, err = s.DB.ExecContext(ctx, query, queue.Name, queueBytes, nowMs, nowMs)
-	if err != nil {
-		if isUniqueConstraintError(err) {
-			return domainerror.New(domainerror.AlreadyExists, fmt.Sprintf("queue %q already exists", queue.Name), err)
+	return s.WithSerializableTransaction(ctx, func(tx *sql.Tx) error {
+		metadata := queue.GetMetadata()
+		if dlqName := metadata.GetDeadLetterQueueName(); dlqName != "" && !metadata.GetAutoCreateDlq() {
+			var exists int
+			if err := tx.QueryRowContext(ctx, `SELECT 1 FROM cq_queues WHERE name = ?`, dlqName).Scan(&exists); err != nil {
+				if err == sql.ErrNoRows {
+					return domainerror.New(domainerror.NotFound, fmt.Sprintf("dead letter queue %q not found", dlqName), err)
+				}
+				return fmt.Errorf("query dead letter queue: %w", err)
+			}
 		}
-		return fmt.Errorf("insert queue: %w", err)
-	}
 
-	return nil
+		query := `INSERT INTO cq_queues (name, metadata_pb, created_at, updated_at) VALUES (?, ?, ?, ?)`
+		nowMs := s.nowMs()
+		if _, err := tx.ExecContext(ctx, query, queue.Name, queueBytes, nowMs, nowMs); err != nil {
+			if isUniqueConstraintError(err) {
+				return domainerror.New(domainerror.AlreadyExists, fmt.Sprintf("queue %q already exists", queue.Name), err)
+			}
+			return fmt.Errorf("insert queue: %w", err)
+		}
+
+		return nil
+	})
 }
 
 // GetQueue retrieves a queue by name
@@ -103,19 +115,43 @@ func (s *Storage) ListQueuesWithPrefix(ctx context.Context, prefix string) ([]*q
 
 // DeleteQueue deletes a queue
 func (s *Storage) DeleteQueue(ctx context.Context, name string) error {
-	query := `DELETE FROM cq_queues WHERE name = ?`
-	result, err := s.DB.ExecContext(ctx, query, name)
-	if err != nil {
-		return fmt.Errorf("delete queue: %w", err)
-	}
+	return s.WithSerializableTransaction(ctx, func(tx *sql.Tx) error {
+		var exists int
+		if err := tx.QueryRowContext(ctx, `SELECT 1 FROM cq_queues WHERE name = ?`, name).Scan(&exists); err != nil {
+			if err == sql.ErrNoRows {
+				return domainerror.New(domainerror.NotFound, fmt.Sprintf("queue %q not found", name), err)
+			}
+			return fmt.Errorf("query queue for deletion: %w", err)
+		}
 
-	rows, err := result.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("get rows affected: %w", err)
-	}
-	if rows == 0 {
-		return domainerror.New(domainerror.NotFound, fmt.Sprintf("queue %q not found", name), nil)
-	}
+		rows, err := tx.QueryContext(ctx, `SELECT metadata_pb FROM cq_queues WHERE name <> ?`, name)
+		if err != nil {
+			return fmt.Errorf("query queue references: %w", err)
+		}
+		defer func() { _ = rows.Close() }()
+		for rows.Next() {
+			var queueBytes []byte
+			if err := rows.Scan(&queueBytes); err != nil {
+				return fmt.Errorf("scan queue reference: %w", err)
+			}
+			queue, err := s.Serializer.UnmarshalQueue(queueBytes)
+			if err != nil {
+				return fmt.Errorf("unmarshal queue reference: %w", err)
+			}
+			if queue.GetMetadata().GetDeadLetterQueueName() == name {
+				return domainerror.New(domainerror.FailedPrecondition, fmt.Sprintf("queue %q is referenced as a dead letter queue by %q", name, queue.GetName()), nil)
+			}
+		}
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("iterate queue references: %w", err)
+		}
+		if err := rows.Close(); err != nil {
+			return fmt.Errorf("close queue references: %w", err)
+		}
 
-	return nil
+		if _, err := tx.ExecContext(ctx, `DELETE FROM cq_queues WHERE name = ?`, name); err != nil {
+			return fmt.Errorf("delete queue: %w", err)
+		}
+		return nil
+	})
 }

--- a/pkg/schema/postgres_storage.go
+++ b/pkg/schema/postgres_storage.go
@@ -210,7 +210,7 @@ func (r *PostgresRegistry) GetLatest(ctx context.Context, schemaID string) (*sch
         SELECT schema_id, version, name, description, content,
                content_type, metadata_json, is_active, created_at, updated_at
         FROM cq_schemas
-        WHERE schema_id = $1
+		WHERE schema_id = $1 AND is_active = TRUE
         ORDER BY version DESC
         LIMIT 1
     `, schemaID).Scan(
@@ -255,21 +255,23 @@ func (r *PostgresRegistry) ListWithOptions(ctx context.Context, options ListOpti
 	}
 
 	rows, err := r.db.QueryContext(ctx, `
-		WITH ranked AS (
-			SELECT s.*, ROW_NUMBER() OVER (PARTITION BY schema_id ORDER BY version DESC) AS row_number,
-			       COUNT(*) OVER (PARTITION BY schema_id) AS version_count,
-			       MIN(created_at) OVER (PARTITION BY schema_id) AS first_created_at,
-			       MAX(updated_at) OVER (PARTITION BY schema_id) AS last_updated_at
-			FROM cq_schemas s
+		WITH family_stats AS (
+			SELECT schema_id, COUNT(*) AS version_count, MIN(created_at) AS first_created_at,
+			       MAX(updated_at) AS last_updated_at
+			FROM cq_schemas
 			WHERE STRPOS(schema_id, $2) = 1
+			GROUP BY schema_id
+		), ranked AS (
+			SELECT s.*, ROW_NUMBER() OVER (PARTITION BY s.schema_id ORDER BY s.version DESC) AS row_number
+			FROM cq_schemas s
+			WHERE STRPOS(s.schema_id, $2) = 1 AND ($1 = FALSE OR s.is_active = TRUE)
 		), latest AS (
 			SELECT * FROM ranked WHERE row_number = 1
 		)
 		SELECT schema_id, version, name, description, content, content_type, metadata_json,
-		       is_active, created_at, updated_at, version_count, first_created_at,
-		       last_updated_at, COUNT(*) OVER ()
-		FROM latest
-		WHERE ($1 = FALSE OR is_active = TRUE)
+		       is_active, created_at, updated_at, family_stats.version_count,
+		       family_stats.first_created_at, family_stats.last_updated_at, COUNT(*) OVER ()
+		FROM latest JOIN family_stats USING (schema_id)
 		ORDER BY schema_id
 		LIMIT $3
 	`, options.ActiveOnly, options.Prefix, options.Limit)

--- a/pkg/schema/postgres_storage_integration_test.go
+++ b/pkg/schema/postgres_storage_integration_test.go
@@ -90,4 +90,14 @@ func TestPostgresRegistryActiveSelectionFallsBackFromInactiveLatestVersion(t *te
 	require.Len(t, listed.Schemas, 1)
 	require.Equal(t, int32(1), listed.Schemas[0].GetVersion())
 	require.Equal(t, int32(2), listed.Metadata["active-fallback"].TotalVersions)
+
+	_, err = registry.Deactivate(ctx, "active-fallback", 1)
+	require.NoError(t, err)
+	_, err = registry.GetLatest(ctx, "active-fallback")
+	require.Error(t, err)
+	validation, err := registry.Validate(ctx, "active-fallback", 0, []byte(`{}`))
+	require.NoError(t, err)
+	require.False(t, validation.GetValid())
+	require.NotEmpty(t, validation.GetErrors())
+	require.Equal(t, schemapb.ErrorCode_SCHEMA_NOT_FOUND.String(), validation.GetErrors()[0].GetErrorCode())
 }

--- a/pkg/schema/postgres_storage_integration_test.go
+++ b/pkg/schema/postgres_storage_integration_test.go
@@ -53,3 +53,41 @@ func TestPostgresRegistryRoundTripsMetadata(t *testing.T) {
 	_, err = registry.Get(ctx, "events", 1)
 	require.ErrorContains(t, err, "decode schema metadata")
 }
+
+func TestPostgresRegistryActiveSelectionFallsBackFromInactiveLatestVersion(t *testing.T) {
+	ctx := context.Background()
+	container, err := postgrescontainer.Run(ctx, "postgres:17-alpine",
+		postgrescontainer.WithDatabase("chronoqueue"),
+		postgrescontainer.WithUsername("chronoqueue"),
+		postgrescontainer.WithPassword("chronoqueue"),
+		postgrescontainer.BasicWaitStrategies(),
+		testcontainers.WithTmpfs(map[string]string{"/var/lib/postgresql/data": "rw"}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, container.Terminate(ctx)) })
+	dsn, err := container.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	registry, err := NewPostgresRegistry(db, log.NewLogger())
+	require.NoError(t, err)
+	for range 2 {
+		_, err := registry.Register(ctx, &schemapb.Schema{
+			SchemaId: "active-fallback", Name: "Active fallback", Content: `{"type":"object"}`,
+		})
+		require.NoError(t, err)
+	}
+	_, err = registry.Deactivate(ctx, "active-fallback", 2)
+	require.NoError(t, err)
+
+	latest, err := registry.GetLatest(ctx, "active-fallback")
+	require.NoError(t, err)
+	require.Equal(t, int32(1), latest.GetVersion())
+	listed, err := registry.ListWithOptions(ctx, ListOptions{Prefix: "active-fallback", Limit: 10, ActiveOnly: true})
+	require.NoError(t, err)
+	require.Len(t, listed.Schemas, 1)
+	require.Equal(t, int32(1), listed.Schemas[0].GetVersion())
+	require.Equal(t, int32(2), listed.Metadata["active-fallback"].TotalVersions)
+}

--- a/pkg/schema/sqlite_storage.go
+++ b/pkg/schema/sqlite_storage.go
@@ -256,7 +256,7 @@ func (s *SQLiteRegistry) GetLatest(ctx context.Context, schemaID string) (*schem
 		SELECT schema_id, version, name, description, content, 
 		       content_type, metadata_json, is_active, created_at, updated_at
 		FROM cq_schemas
-		WHERE schema_id = ?
+		WHERE schema_id = ? AND is_active = 1
 		ORDER BY version DESC
 		LIMIT 1
 	`, schemaID).Scan(
@@ -301,24 +301,26 @@ func (s *SQLiteRegistry) ListWithOptions(ctx context.Context, options ListOption
 	}
 
 	rows, err := s.db.QueryContext(ctx, `
-		WITH ranked AS (
-			SELECT s.*, ROW_NUMBER() OVER (PARTITION BY schema_id ORDER BY version DESC) AS row_number,
-			       COUNT(*) OVER (PARTITION BY schema_id) AS version_count,
-			       MIN(created_at) OVER (PARTITION BY schema_id) AS first_created_at,
-			       MAX(updated_at) OVER (PARTITION BY schema_id) AS last_updated_at
-			FROM cq_schemas s
+		WITH family_stats AS (
+			SELECT schema_id, COUNT(*) AS version_count, MIN(created_at) AS first_created_at,
+			       MAX(updated_at) AS last_updated_at
+			FROM cq_schemas
 			WHERE instr(schema_id, ?) = 1
+			GROUP BY schema_id
+		), ranked AS (
+			SELECT s.*, ROW_NUMBER() OVER (PARTITION BY s.schema_id ORDER BY s.version DESC) AS row_number
+			FROM cq_schemas s
+			WHERE instr(s.schema_id, ?) = 1 AND (? = 0 OR s.is_active = 1)
 		), latest AS (
 			SELECT * FROM ranked WHERE row_number = 1
 		)
 		SELECT schema_id, version, name, description, content, content_type, metadata_json,
-		       is_active, created_at, updated_at, version_count, first_created_at,
-		       last_updated_at, COUNT(*) OVER ()
-		FROM latest
-		WHERE (? = 0 OR is_active = 1)
+		       is_active, created_at, updated_at, family_stats.version_count,
+		       family_stats.first_created_at, family_stats.last_updated_at, COUNT(*) OVER ()
+		FROM latest JOIN family_stats USING (schema_id)
 		ORDER BY schema_id
 		LIMIT ?
-	`, options.Prefix, options.ActiveOnly, options.Limit)
+	`, options.Prefix, options.Prefix, options.ActiveOnly, options.Limit)
 	if err != nil {
 		return ListResult{}, fmt.Errorf("failed to list schemas: %w", err)
 	}

--- a/pkg/schema/sqlite_storage_test.go
+++ b/pkg/schema/sqlite_storage_test.go
@@ -315,7 +315,7 @@ func TestSQLiteRegistry_List(t *testing.T) {
 	})
 }
 
-func TestSQLiteRegistry_ListWithOptions_ActiveOnlyExcludesInactiveLatestVersion(t *testing.T) {
+func TestSQLiteRegistry_ActiveSelectionFallsBackFromInactiveLatestVersion(t *testing.T) {
 	registry, cleanup := setupTestSQLiteRegistry(t)
 	defer cleanup()
 
@@ -334,8 +334,19 @@ func TestSQLiteRegistry_ListWithOptions_ActiveOnlyExcludesInactiveLatestVersion(
 
 	activeOnly, err := registry.ListWithOptions(ctx, ListOptions{Prefix: schemaID, Limit: 100, ActiveOnly: true})
 	require.NoError(t, err)
-	assert.Empty(t, activeOnly.Schemas)
-	assert.Zero(t, activeOnly.TotalCount)
+	require.Len(t, activeOnly.Schemas, 1)
+	assert.Equal(t, int32(1), activeOnly.Schemas[0].GetVersion())
+	assert.True(t, activeOnly.Schemas[0].GetIsActive())
+	assert.Equal(t, int32(1), activeOnly.TotalCount)
+
+	latest, err := registry.GetLatest(ctx, schemaID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), latest.GetVersion())
+
+	validation, err := registry.Validate(ctx, schemaID, 0, []byte(`{"field":"value"}`))
+	require.NoError(t, err)
+	require.True(t, validation.GetValid())
+	assert.Equal(t, int32(1), validation.GetSchemaVersion())
 
 	all, err := registry.ListWithOptions(ctx, ListOptions{Prefix: schemaID, Limit: 100})
 	require.NoError(t, err)
@@ -405,6 +416,15 @@ func TestSQLiteRegistry_DeactivateAllVersions(t *testing.T) {
 	result, err := registry.ListWithOptions(ctx, ListOptions{Prefix: "deactivate-all.test", Limit: 10, ActiveOnly: true})
 	require.NoError(t, err)
 	assert.Empty(t, result.Schemas)
+
+	_, err = registry.GetLatest(ctx, "deactivate-all.test")
+	require.ErrorContains(t, err, "schema")
+
+	validation, err := registry.Validate(ctx, "deactivate-all.test", 0, []byte(`{}`))
+	require.NoError(t, err)
+	require.False(t, validation.GetValid())
+	require.NotEmpty(t, validation.GetErrors())
+	assert.Equal(t, schema_pb.ErrorCode_SCHEMA_NOT_FOUND.String(), validation.GetErrors()[0].GetErrorCode())
 }
 
 func TestSQLiteRegistry_RegisterRejectsExistingVersion(t *testing.T) {

--- a/tests/integration/message_lifecycle_test.go
+++ b/tests/integration/message_lifecycle_test.go
@@ -481,8 +481,8 @@ func TestMessageLifecycle_RenewMessageLease(t *testing.T) {
 	// Assert
 	require.NoError(t, err, "Lease renewal should succeed")
 	assert.NotNil(t, renewResp.RemainingTime, "Should return remaining time")
-	assert.Greater(t, renewResp.GetRemainingTime().AsDuration(), 44*time.Second)
-	assert.LessOrEqual(t, renewResp.GetRemainingTime().AsDuration(), 45*time.Second)
+	assert.Greater(t, renewResp.GetRemainingTime().AsDuration(), 73*time.Second)
+	assert.LessOrEqual(t, renewResp.GetRemainingTime().AsDuration(), 75*time.Second)
 	assert.Equal(t, message_pb.Message_Metadata_RUNNING, renewResp.GetState())
 	t.Logf("Lease renewed successfully, remaining time: %v", renewResp.RemainingTime)
 }

--- a/tests/integration/message_lifecycle_test.go
+++ b/tests/integration/message_lifecycle_test.go
@@ -481,6 +481,9 @@ func TestMessageLifecycle_RenewMessageLease(t *testing.T) {
 	// Assert
 	require.NoError(t, err, "Lease renewal should succeed")
 	assert.NotNil(t, renewResp.RemainingTime, "Should return remaining time")
+	assert.Greater(t, renewResp.GetRemainingTime().AsDuration(), 44*time.Second)
+	assert.LessOrEqual(t, renewResp.GetRemainingTime().AsDuration(), 45*time.Second)
+	assert.Equal(t, message_pb.Message_Metadata_RUNNING, renewResp.GetState())
 	t.Logf("Lease renewed successfully, remaining time: %v", renewResp.RemainingTime)
 }
 

--- a/tests/integration/queue_operations_test.go
+++ b/tests/integration/queue_operations_test.go
@@ -126,6 +126,15 @@ func TestQueueOperations_CreateQueueWithDLQ_Success(t *testing.T) {
 	})
 	require.NoError(t, err, "DLQ should exist")
 	assert.NotNil(t, dlqState, "DLQ state should be returned")
+
+	_, err = client.DeleteQueue(ctx, &queueservice_pb.DeleteQueueRequest{Name: dlqName})
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+	require.ErrorContains(t, err, "referenced as a dead letter queue")
+
+	_, err = client.DeleteQueue(ctx, &queueservice_pb.DeleteQueueRequest{Name: queueName})
+	require.NoError(t, err)
+	_, err = client.DeleteQueue(ctx, &queueservice_pb.DeleteQueueRequest{Name: dlqName})
+	require.NoError(t, err)
 }
 
 // TestQueueOperations_DeleteEmptyQueue_Success validates deleting an empty queue.

--- a/tests/integration/sqlite_schema_test.go
+++ b/tests/integration/sqlite_schema_test.go
@@ -191,10 +191,10 @@ func TestSQLiteSchemaIntegration(t *testing.T) {
 		assert.Equal(t, int32(2), resp.GetVersion())
 	})
 
-	t.Run("DeleteSchemaVersion", func(t *testing.T) {
+	t.Run("DeactivateLatestFallsBackToActiveVersion", func(t *testing.T) {
 		resp, err := client.DeleteSchema(ctx, &queueservicepb.DeleteSchemaRequest{
 			SchemaId: "user.profile.v1",
-			Version:  1,
+			Version:  2,
 		})
 		require.NoError(t, err)
 		assert.True(t, resp.GetSuccess())
@@ -202,7 +202,7 @@ func TestSQLiteSchemaIntegration(t *testing.T) {
 
 		schemaResp, err := client.GetSchema(ctx, &queueservicepb.GetSchemaRequest{
 			SchemaId: "user.profile.v1",
-			Version:  1,
+			Version:  2,
 		})
 		require.NoError(t, err)
 		require.NotNil(t, schemaResp.GetSchema())
@@ -212,13 +212,17 @@ func TestSQLiteSchemaIntegration(t *testing.T) {
 			ActiveOnly: true,
 		})
 		require.NoError(t, err)
-		foundActiveV2 := false
+		foundActiveV1 := false
 		for _, s := range activeOnlyResp.GetSchemas() {
-			if s.GetSchemaId() == "user.profile.v1" && s.GetLatestVersion() == 2 {
-				foundActiveV2 = true
+			if s.GetSchemaId() == "user.profile.v1" && s.GetLatestVersion() == 1 {
+				foundActiveV1 = true
 			}
 		}
-		assert.True(t, foundActiveV2, "schema user.profile.v1 should remain active via version 2")
+		assert.True(t, foundActiveV1, "schema user.profile.v1 should fall back to active version 1")
+
+		latest, err := client.GetSchema(ctx, &queueservicepb.GetSchemaRequest{SchemaId: "user.profile.v1"})
+		require.NoError(t, err)
+		assert.Equal(t, int32(1), latest.GetSchema().GetVersion())
 	})
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Lease renewal now reports the actual remaining lease duration.
  * Scheduled messages are activated safely once, preventing duplicate processing.
  * Active schema lookups fall back to the latest active version when newer versions are inactive.

* **Bug Fixes**
  * Queues now validate referenced dead-letter queues before creation.
  * Dead-letter queues cannot be deleted while still referenced.
  * Lease extensions respect configured maximum limits.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->